### PR TITLE
Changed pyramidPlatform assignment

### DIFF
--- a/sm64-tas-scripting/GetMinimumDownhillWalkingAngle.cpp
+++ b/sm64-tas-scripting/GetMinimumDownhillWalkingAngle.cpp
@@ -6,6 +6,21 @@
 
 bool GetMinimumDownhillWalkingAngle::verification()
 {
+	//Check if Mario is on the pyramid platform
+	MarioState* marioState = *(MarioState**)(game->addr("gMarioState"));
+
+	Surface* floor = marioState->floor;
+	if (!floor)
+		return false;
+
+	Object* floorObject = floor->object;
+	if (!floorObject)
+		return false;
+
+	const BehaviorScript* pyramidBehavior = (const BehaviorScript*)(game->addr("bhvBitfsTiltingInvertedPyramid"));
+	if (floorObject->behavior != pyramidBehavior)
+		return false;
+
 	return true;
 }
 

--- a/sm64-tas-scripting/GetMinimumDownhillWalkingAngle.cpp
+++ b/sm64-tas-scripting/GetMinimumDownhillWalkingAngle.cpp
@@ -44,9 +44,7 @@ bool GetMinimumDownhillWalkingAngle::execution()
 	*/
 
 	Object* marioObj = marioState->marioObj;
-
-	int pyramidID = 84;
-    Object* pyramidPlatform = (Object*)(game->addr("gObjectPool") + 1392*pyramidID);
+	Object* pyramidPlatform = marioState->floor->object;
 
 	short floorAngle = 0;
 


### PR DESCRIPTION
Due to checks in the script that calls it, Mario is always guaranteed to be on the pyramid platform here. So there's no need to hard code its address.