### PR TITLE
Minor oscillation logic fixes

### DIFF
--- a/sm64-tas-scripting/BitFsPyramidOscillation.cpp
+++ b/sm64-tas-scripting/BitFsPyramidOscillation.cpp
@@ -66,10 +66,11 @@ bool BitFsPyramidOscillation::execution()
 	for (int i = 0; i < 12; i++)
 	{
 		ScriptStatus<BitFsPyramidOscillation_TurnThenRunDownhill> turnRunStatus;
+		float speedBeforeTurning = 0;
 		for (uint64_t frame = maxFrame; frame >= minFrame; frame--)
 		{
 			Load(frame);
-
+			speedBeforeTurning = marioState->forwardVel;
 			auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill>(CustomStatus.maxSpeed[i & 1], CustomStatus.initialXzSum);
 
 			//Keep iterating until we get a valid result, then keep iterating until we stop getting better results
@@ -91,7 +92,7 @@ bool BitFsPyramidOscillation::execution()
 		if (turnRunStatus.passedEquilibriumSpeed > CustomStatus.maxPassedEquilibriumSpeed[i & 1])
 		{
 			CustomStatus.finalXzSum = turnRunStatus.finalXzSum;
-			CustomStatus.maxSpeed[i & 1] = turnRunStatus.maxSpeed;
+			CustomStatus.maxSpeed[(i & 1) ^ 1] = speedBeforeTurning;
 			CustomStatus.maxPassedEquilibriumSpeed[i & 1] = turnRunStatus.passedEquilibriumSpeed;
 			Apply(turnRunStatus.m64Diff);
 			minFrame = turnRunStatus.framePassedEquilibriumPoint;

--- a/sm64-tas-scripting/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
+++ b/sm64-tas-scripting/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
@@ -61,7 +61,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 			return false;
 		}
 
-	} while (marioState->faceAngle[1] != actualIntendedYaw);
+	} while (marioState->faceAngle[1] != actualIntendedYaw || marioState->action == ACT_FINISH_TURNING_AROUND);
 
 	if (marioState->action != ACT_WALKING)
 	{
@@ -83,6 +83,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 
 		//We've gone too far uphill, terminate
 		if (status.tooUphill)
+			break;
 
 		//Extra running frames are no longer helping, terminate
 		//Note that this requires a previous valid status to trigger


### PR DESCRIPTION
-run downhill paths need only exceed the speed of the last iteration in the same direction PRIOR to turning for the NEXT iteration. This is not known until said next iteration has completed
-terminate correctly if turn around path is too uphill
-ensure finish turning around action has completed before trying to turn around again
-avoid double turnaround glitch