### PR TITLE
Add braking + quickturn turnaround option into oscillation script

### DIFF
--- a/sm64-tas-scripting/BitFsPyramidOscillation_Iteration.cpp
+++ b/sm64-tas-scripting/BitFsPyramidOscillation_Iteration.cpp
@@ -1,0 +1,78 @@
+#include "Script.hpp"
+
+bool BitFsPyramidOscillation_Iteration::verification()
+{
+	//Verify Mario is running on the platform
+	MarioState* marioState = *(MarioState**)(game->addr("gMarioState"));
+
+	Surface* floor = marioState->floor;
+	if (!floor)
+		return false;
+
+	Object* floorObject = floor->object;
+	if (!floorObject)
+		return false;
+
+	const BehaviorScript* pyramidBehavior = (const BehaviorScript*)(game->addr("bhvBitfsTiltingInvertedPyramid"));
+	if (floorObject->behavior != pyramidBehavior)
+		return false;
+
+	//Check that Mario can enter walking action
+	uint32_t action = marioState->action;
+	if (action != ACT_WALKING && action != ACT_FINISH_TURNING_AROUND)
+		return false;
+
+	return true;
+}
+
+bool BitFsPyramidOscillation_Iteration::execution()
+{
+	MarioState* marioState = *(MarioState**)(game->addr("gMarioState"));
+	Camera* camera = *(Camera**)(game->addr("gCamera"));
+	Object* pyramid = marioState->floor->object;
+
+	ScriptStatus<BitFsPyramidOscillation_TurnThenRunDownhill> turnRunStatus;
+	for (uint64_t frame = _maxFrame; frame >= _minFrame; frame--)
+	{
+		Load(frame);
+		CustomStatus.speedBeforeTurning = marioState->forwardVel;
+		auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill>(_prevMaxSpeed, _minXzSum, _brake);
+
+		//Keep iterating until we get a valid result, then keep iterating until we stop getting better results
+		//Once we get a valid result, we expect successive iterations to be worse (less space to accelerate), but that isn't always true
+		if (!status.validated)
+		{
+			if (turnRunStatus.passedEquilibriumSpeed == 0.0f)
+				continue;
+			else
+				break;
+		}
+
+		if (status.passedEquilibriumSpeed > turnRunStatus.passedEquilibriumSpeed)
+			turnRunStatus = status;
+		else if (status.maxSpeed == 0.0f)
+			break;
+	}
+
+	if (!turnRunStatus.validated)
+		return false;
+
+	CustomStatus.initialXzSum = _minXzSum;
+	CustomStatus.finalXzSum = turnRunStatus.finalXzSum;
+	CustomStatus.maxSpeed = turnRunStatus.maxSpeed;
+	CustomStatus.passedEquilibriumSpeed = turnRunStatus.passedEquilibriumSpeed;
+	CustomStatus.framePassedEquilibriumPoint = turnRunStatus.framePassedEquilibriumPoint;
+	CustomStatus.finishTurnaroundFailedToExpire = turnRunStatus.finishTurnaroundFailedToExpire;
+
+	Apply(turnRunStatus.m64Diff);
+
+	return true;
+}
+
+bool BitFsPyramidOscillation_Iteration::validation()
+{
+	if (BaseStatus.m64Diff.frames.empty())
+		return false;
+
+	return true;
+}

--- a/sm64-tas-scripting/BitFsPyramidOscillation_RunDownhill.cpp
+++ b/sm64-tas-scripting/BitFsPyramidOscillation_RunDownhill.cpp
@@ -45,8 +45,7 @@ bool BitFsPyramidOscillation_RunDownhill::execution()
 		float prevNormalZ = pyramid->oTiltingPyramidNormalZ;
 
 		//Turnaround face angle is not guaranteed to be closer to one orientation or the other, so rely on caller to specify a close-enough target orientation
-		int16_t targetAngle = marioState->action == ACT_TURNING_AROUND ? _roughTargetAngle : marioState->faceAngle[1];
-		auto status = Test<GetMinimumDownhillWalkingAngle>(targetAngle, marioState->faceAngle[1]);
+		auto status = Test<GetMinimumDownhillWalkingAngle>(_roughTargetAngle, marioState->faceAngle[1]);
 
 		//Terminate if unable to locate a downhill angle
 		if (!status.executed)

--- a/sm64-tas-scripting/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
+++ b/sm64-tas-scripting/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
@@ -55,6 +55,8 @@ bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::execution()
 			//If double turnaround glitch occurs, run for one extra frame in current direction to change animation
 			if (marioState->action == ACT_WALKING && marioState->prevAction == ACT_TURNING_AROUND)
 			{
+				CustomStatus.finishTurnaroundFailedToExpire = true;
+
 				Rollback(GetCurrentFrame() - 1);
 				inputs = Inputs::GetClosestInputByYawHau(marioState->faceAngle[1], 32, camera->yaw);
 				AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));

--- a/sm64-tas-scripting/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
+++ b/sm64-tas-scripting/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
@@ -35,43 +35,55 @@ bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::execution()
 	Object* pyramid = marioState->floor->object;
 
 	//Turn around
-	do
+	if (_brake)
 	{
-		auto inputs = Inputs::GetClosestInputByYawHau(marioState->faceAngle[1] + 0x8000, 32, camera->yaw);
-		AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
-
-		//If double turnaround glitch occurs, run for one extra frame in current direction to change animation
-		if (marioState->action == ACT_WALKING && marioState->prevAction == ACT_TURNING_AROUND)
-		{
-			Rollback(GetCurrentFrame() - 1);
-			inputs = Inputs::GetClosestInputByYawHau(marioState->faceAngle[1], 32, camera->yaw);
-			AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
-
-			if ((marioState->action != ACT_WALKING)
-				|| marioState->floor->object == NULL
-				|| marioState->floor->object->behavior != pyramidBehavior)
-				return false;
-
-			//Try and turn around again
-			inputs = Inputs::GetClosestInputByYawHau(marioState->faceAngle[1] + 0x8000, 32, camera->yaw);
-			AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
-		}
-
-		if (marioState->action != ACT_TURNING_AROUND && marioState->action != ACT_FINISH_TURNING_AROUND)
+		//Works with short oscialltion cycles, but takes an extra turnaround frame
+		auto status = Modify<BrakeToIdle>();
+		if (!status.validated)
 		{
 			CustomStatus.tooDownhill = (marioState->action == ACT_LAVA_BOOST);
 			return false;
 		}
-
-		if (marioState->floor->object == NULL || marioState->floor->object->behavior != pyramidBehavior)
+	}
+	else
+	{
+		do
 		{
-			CustomStatus.tooDownhill = (marioState->floor->object == NULL);
-			return false;
-		}
-	} while (marioState->action == ACT_TURNING_AROUND);
+			auto inputs = Inputs::GetClosestInputByYawHau(marioState->faceAngle[1] + 0x8000, 32, camera->yaw);
+			AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
 
-	//Wind back 1f and run downhill optimally
-	Rollback(GetCurrentFrame() - 1);
+			//If double turnaround glitch occurs, run for one extra frame in current direction to change animation
+			if (marioState->action == ACT_WALKING && marioState->prevAction == ACT_TURNING_AROUND)
+			{
+				Rollback(GetCurrentFrame() - 1);
+				inputs = Inputs::GetClosestInputByYawHau(marioState->faceAngle[1], 32, camera->yaw);
+				AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
+
+				if ((marioState->action != ACT_WALKING)
+					|| marioState->floor->object == NULL
+					|| marioState->floor->object->behavior != pyramidBehavior)
+					return false;
+
+				//Try and turn around again
+				inputs = Inputs::GetClosestInputByYawHau(marioState->faceAngle[1] + 0x8000, 32, camera->yaw);
+				AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
+			}
+
+			if (marioState->action != ACT_TURNING_AROUND && marioState->action != ACT_FINISH_TURNING_AROUND)
+			{
+				CustomStatus.tooDownhill = (marioState->action == ACT_LAVA_BOOST);
+				return false;
+			}
+
+			if (marioState->floor->object == NULL || marioState->floor->object->behavior != pyramidBehavior)
+			{
+				CustomStatus.tooDownhill = (marioState->floor->object == NULL);
+				return false;
+			}
+		} while (marioState->action == ACT_TURNING_AROUND);
+
+		Rollback(GetCurrentFrame() - 1);
+	}
 
 	auto status = Modify<BitFsPyramidOscillation_RunDownhill>(_roughTargetAngle);
 

--- a/sm64-tas-scripting/BitFsPyramidOscillation_TurnThenRunDownhill.cpp
+++ b/sm64-tas-scripting/BitFsPyramidOscillation_TurnThenRunDownhill.cpp
@@ -44,7 +44,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill::execution()
 	ScriptStatus<BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle> runStatus;
 	for (int32_t angle = midHau; angle * -downhillRotation >= extremeDownhillHau * -downhillRotation; angle += 512 * downhillRotation)
 	{
-		auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle>(angle, _prevMaxSpeed, _minXzSum);
+		auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle>(angle, _prevMaxSpeed, _minXzSum, _brake);
 
 		if (!status.validated)
 		{
@@ -60,7 +60,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill::execution()
 
 	for (int32_t angle = midHau - 512 * downhillRotation; angle * -downhillRotation <= extremeUphillHau * -downhillRotation; angle -= 512 * downhillRotation)
 	{
-		auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle>(angle, _prevMaxSpeed, _minXzSum);
+		auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle>(angle, _prevMaxSpeed, _minXzSum, _brake);
 
 		if (!status.validated)
 		{
@@ -81,6 +81,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill::execution()
 	CustomStatus.framePassedEquilibriumPoint = runStatus.framePassedEquilibriumPoint;
 	CustomStatus.maxSpeed = runStatus.maxSpeed;
 	CustomStatus.passedEquilibriumSpeed = runStatus.passedEquilibriumSpeed;
+	CustomStatus.finishTurnaroundFailedToExpire = runStatus.finishTurnaroundFailedToExpire;
 
 	Apply(runStatus.m64Diff);
 

--- a/sm64-tas-scripting/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
+++ b/sm64-tas-scripting/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
@@ -127,6 +127,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 	CustomStatus.maxSpeed = runDownhillStatus.maxSpeed;
 	CustomStatus.passedEquilibriumSpeed = runDownhillStatus.passedEquilibriumSpeed;
 	CustomStatus.finalXzSum = runDownhillStatus.finalXzSum;
+	CustomStatus.finishTurnaroundFailedToExpire |= runDownhillStatus.finishTurnaroundFailedToExpire;
 
 	Apply(runDownhillStatus.m64Diff);
 

--- a/sm64-tas-scripting/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
+++ b/sm64-tas-scripting/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
@@ -61,6 +61,9 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 			return false;
 		}
 
+		//Check if we need extra frames to wait for ACT_FINISH_TURNING_AROUND to expire
+		if (marioState->faceAngle[1] == actualIntendedYaw && marioState->action == ACT_FINISH_TURNING_AROUND)
+			CustomStatus.finishTurnaroundFailedToExpire = true;
 	} while (marioState->faceAngle[1] != actualIntendedYaw || marioState->action == ACT_FINISH_TURNING_AROUND);
 
 	if (marioState->action != ACT_WALKING)
@@ -75,7 +78,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 	for (int i = 0; i < 50; i++)
 	{
 		//Immediately turn around and run downhill optimally
-		auto status = Execute<BitFsPyramidOscillation_TurnAroundAndRunDownhill>(roughTargetAngle);
+		auto status = Execute<BitFsPyramidOscillation_TurnAroundAndRunDownhill>(_brake, roughTargetAngle);
 
 		//Something weird happened, terminate
 		if (!status.validated)

--- a/sm64-tas-scripting/BrakeToIdle.cpp
+++ b/sm64-tas-scripting/BrakeToIdle.cpp
@@ -1,0 +1,69 @@
+#include "Script.hpp"
+
+bool BrakeToIdle::verification()
+{
+	//Check if Mario is on the pyramid platform
+	MarioState* marioState = *(MarioState**)(game->addr("gMarioState"));
+
+	Surface* floor = marioState->floor;
+	if (!floor)
+		return false;
+
+	//Verify mario has enough speed to brake
+	if (marioState->forwardVel < 16.0f)
+		return false;
+
+	//Check that Mario can enter walking action
+	if (marioState->action != ACT_WALKING)
+		return false;
+
+	return true;
+}
+
+bool BrakeToIdle::execution()
+{
+	const BehaviorScript* pyramidBehavior = (const BehaviorScript*)(game->addr("bhvBitfsTiltingInvertedPyramid"));
+	MarioState* marioState = *(MarioState**)(game->addr("gMarioState"));
+	Camera* camera = *(Camera**)(game->addr("gCamera"));
+	Object* pyramid = marioState->floor->object;
+	
+	//Brake to a stop
+	do
+	{
+		AdvanceFrameWrite(Inputs(0, 0, 0));
+
+		if (marioState->action != ACT_BRAKING && marioState->action != ACT_BRAKING_STOP)
+			return false;
+
+	} while (marioState->action == ACT_BRAKING);
+
+	//Quickturn uphill
+	auto status = Test<GetMinimumDownhillWalkingAngle>(marioState->faceAngle[1]);
+	if (!status.validated)
+		return false;
+
+	//Get closest cardinal controller input to uphill angle
+	int16_t uphillCardinalYaw = (((uint16_t)(status.floorAngle + 0x8000 - camera->yaw + 0x2000) >> 14) << 14) + camera->yaw;
+	auto inputs = Inputs::GetClosestInputByYawHau(uphillCardinalYaw, nextafter(0.0f, 1.0f), camera->yaw);
+	AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
+
+	if (marioState->action != ACT_WALKING)
+		return false;
+
+	do
+	{
+		AdvanceFrameWrite(Inputs(0, 0, 0));
+		CustomStatus.decelerationFrames++;
+	} while (marioState->action == ACT_DECELERATING);
+
+	return true;
+}
+
+bool BrakeToIdle::validation()
+{
+	MarioState* marioState = *(MarioState**)(game->addr("gMarioState"));
+	if (marioState->action != ACT_IDLE)
+		return false;
+
+	return true;
+}

--- a/sm64-tas-scripting/GetMinimumDownhillWalkingAngle.cpp
+++ b/sm64-tas-scripting/GetMinimumDownhillWalkingAngle.cpp
@@ -63,7 +63,8 @@ bool GetMinimumDownhillWalkingAngle::execution()
 
 	short floorAngle = 0;
 
-	simulate_platform_tilt(marioObj, pyramidPlatform, &floorAngle, &CustomStatus.isSlope);
+	if (!simulate_platform_tilt(marioObj, pyramidPlatform, &floorAngle, &CustomStatus.isSlope))
+		return false;
 
 	//m->floorAngle - m->faceAngle[1] >= -0x3FFF && m->floorAngle - m->faceAngle[1] <= 0x3FFF
 	int32_t lowerAngle = floorAngle + 0x3FFF;
@@ -97,6 +98,8 @@ bool GetMinimumDownhillWalkingAngle::execution()
 		CustomStatus.angleNotFacingAnalogBack = _faceAngle + 0x471D * sign(notFacingDYaw);
 	else
 		CustomStatus.angleNotFacingAnalogBack = CustomStatus.angleNotFacing;
+
+	CustomStatus.floorAngle = floorAngle;
 
 	return true;
 }

--- a/sm64-tas-scripting/Inputs.cpp
+++ b/sm64-tas-scripting/Inputs.cpp
@@ -86,7 +86,7 @@ std::pair<int8_t, int8_t> Inputs::GetClosestInputByYawHau(int16_t intendedYaw, f
 					return yawMagToInputs.at(yaw).at(intendedMag);
 
 				auto upper = yawMagToInputs.at(yaw).upper_bound(intendedMag);
-				auto lower = upper = std::prev(upper);
+				auto lower = std::prev(upper);
 				float magDistance = INFINITY;
 				if (upper == yawMagToInputs.at(yaw).end())
 				{
@@ -95,6 +95,15 @@ std::pair<int8_t, int8_t> Inputs::GetClosestInputByYawHau(int16_t intendedYaw, f
 					{
 						closestMagDistance = magDistance;
 						closestInput = (*lower).second;
+					}
+				}
+				else if (lower == yawMagToInputs.at(yaw).end())
+				{
+					magDistance = (*upper).first - intendedMag;
+					if (magDistance < closestMagDistance)
+					{
+						closestMagDistance = magDistance;
+						closestInput = (*upper).second;
 					}
 				}
 				else
@@ -188,6 +197,15 @@ std::pair<int8_t, int8_t> Inputs::GetClosestInputByYawExact(int16_t intendedYaw,
 				{
 					closestMagDistance = magDistance;
 					closestInput = (*lower).second;
+				}
+			}
+			else if (lower == yawMagToInputs.at(yaw).end())
+			{
+				magDistance = (*upper).first - intendedMag;
+				if (magDistance < closestMagDistance)
+				{
+					closestMagDistance = magDistance;
+					closestInput = (*upper).second;
 				}
 			}
 			else

--- a/sm64-tas-scripting/Script_BitFsPyramidOscillation.hpp
+++ b/sm64-tas-scripting/Script_BitFsPyramidOscillation.hpp
@@ -25,6 +25,38 @@ public:
 	bool validation();
 };
 
+//Find the optimal result of BitFsPyramidOscillation_TurnThenRunDownhill over a range of frames
+class BitFsPyramidOscillation_Iteration : public Script
+{
+public:
+	class CustomScriptStatus
+	{
+	public:
+		float initialXzSum = 0;
+		float finalXzSum = 0;
+		float maxSpeed = 0;
+		float passedEquilibriumSpeed = 0;
+		int64_t framePassedEquilibriumPoint = -1;
+		bool finishTurnaroundFailedToExpire = false;
+		float speedBeforeTurning = 0;
+	};
+	CustomScriptStatus CustomStatus = CustomScriptStatus();
+
+	BitFsPyramidOscillation_Iteration(Script* parentScript, int32_t minFrame, int32_t maxFrame, float prevMaxSpeed, float minXzSum, bool brake)
+		: Script(parentScript), _prevMaxSpeed(prevMaxSpeed), _minXzSum(minXzSum), _brake(brake), _minFrame(minFrame), _maxFrame(maxFrame) {}
+
+	bool verification();
+	bool execution();
+	bool validation();
+
+private:
+	int32_t _minFrame = -1;
+	int32_t _maxFrame = -1;
+	float _prevMaxSpeed = 0;
+	float _minXzSum = 0;
+	bool _brake = false;
+};
+
 class BitFsPyramidOscillation_TurnThenRunDownhill : public Script
 {
 public:
@@ -36,11 +68,12 @@ public:
 		float maxSpeed = 0;
 		float passedEquilibriumSpeed = 0;
 		int64_t framePassedEquilibriumPoint = -1;
+		bool finishTurnaroundFailedToExpire = false;
 	};
 	CustomScriptStatus CustomStatus = CustomScriptStatus();
 
-	BitFsPyramidOscillation_TurnThenRunDownhill(Script* parentScript, float prevMaxSpeed, float minXzSum)
-		: Script(parentScript), _prevMaxSpeed(prevMaxSpeed), _minXzSum(minXzSum) {}
+	BitFsPyramidOscillation_TurnThenRunDownhill(Script* parentScript, float prevMaxSpeed, float minXzSum, bool brake)
+		: Script(parentScript), _prevMaxSpeed(prevMaxSpeed), _minXzSum(minXzSum), _brake(brake) {}
 
 	bool verification();
 	bool execution();
@@ -49,6 +82,7 @@ public:
 private:
 	float _prevMaxSpeed = 0;
 	float _minXzSum = 0;
+	bool _brake = false;
 };
 
 class BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle: public Script
@@ -65,11 +99,12 @@ public:
 		bool tooSlowForTurnAround = false;
 		bool tooUphill = false;
 		bool tooDownhill = false;
+		bool finishTurnaroundFailedToExpire = false;
 	};
 	CustomScriptStatus CustomStatus = CustomScriptStatus();
 
-	BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle(Script* parentScript, int16_t angle, float prevMaxSpeed, float minXzSum)
-		: Script(parentScript), _angle(angle), _prevMaxSpeed(prevMaxSpeed), _minXzSum(minXzSum) {}
+	BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle(Script* parentScript, int16_t angle, float prevMaxSpeed, float minXzSum, bool brake)
+		: Script(parentScript), _angle(angle), _prevMaxSpeed(prevMaxSpeed), _minXzSum(minXzSum), _brake(brake) {}
 
 	bool verification();
 	bool execution();
@@ -79,6 +114,7 @@ private:
 	int16_t _angle;
 	float _prevMaxSpeed = 0;
 	float _minXzSum = 0;
+	bool _brake = false;
 };
 
 class BitFsPyramidOscillation_TurnAroundAndRunDownhill : public Script
@@ -96,8 +132,8 @@ public:
 	};
 	CustomScriptStatus CustomStatus = CustomScriptStatus();
 
-	BitFsPyramidOscillation_TurnAroundAndRunDownhill(Script* parentScript, int16_t roughTargetAngle = 0, float minXzSum = 0)
-		: Script(parentScript), _roughTargetAngle(roughTargetAngle), _minXzSum(minXzSum) {}
+	BitFsPyramidOscillation_TurnAroundAndRunDownhill(Script* parentScript, bool brake, int16_t roughTargetAngle = 0, float minXzSum = 0)
+		: Script(parentScript), _roughTargetAngle(roughTargetAngle), _minXzSum(minXzSum), _brake(brake) {}
 
 	bool verification();
 	bool execution();
@@ -106,6 +142,7 @@ public:
 private:
 	int16_t _roughTargetAngle = 0;
 	float _minXzSum = 0;
+	bool _brake = false;
 };
 
 class BitFsPyramidOscillation_RunDownhill : public Script
@@ -129,7 +166,7 @@ public:
 	};
 	CustomScriptStatus CustomStatus = CustomScriptStatus();
 
-	BitFsPyramidOscillation_RunDownhill(Script* parentScript, int16_t roughTargetAngle = 0)
+	BitFsPyramidOscillation_RunDownhill(Script* parentScript, int16_t roughTargetAngle)
 		: Script(parentScript), _roughTargetAngle(roughTargetAngle) {}
 
 	bool verification();

--- a/sm64-tas-scripting/Script_BitFsPyramidOscillation.hpp
+++ b/sm64-tas-scripting/Script_BitFsPyramidOscillation.hpp
@@ -129,6 +129,7 @@ public:
 		float finalXzSum = 0;
 		bool tooDownhill = false;
 		bool tooUphill = false;
+		bool finishTurnaroundFailedToExpire = false;
 	};
 	CustomScriptStatus CustomStatus = CustomScriptStatus();
 

--- a/sm64-tas-scripting/Script_General.hpp
+++ b/sm64-tas-scripting/Script_General.hpp
@@ -16,6 +16,7 @@ public:
 		int32_t angleNotFacing = 0;
 		int32_t angleFacingAnalogBack = 0;
 		int32_t angleNotFacingAnalogBack = 0;
+		int32_t floorAngle = 0;
 		bool isSlope = false;
 	};
 	CustomScriptStatus CustomStatus = CustomScriptStatus();
@@ -57,6 +58,23 @@ public:
 
 private:
 	float _speed;
+};
+
+class BrakeToIdle : public Script
+{
+public:
+	class CustomScriptStatus
+	{
+	public:
+		int32_t decelerationFrames = -1;
+	};
+	CustomScriptStatus CustomStatus = CustomScriptStatus();
+
+	BrakeToIdle(Script* parentScript) : Script(parentScript) {}
+
+	bool verification();
+	bool execution();
+	bool validation();
 };
 
 #endif

--- a/sm64-tas-scripting/pyramid.cpp
+++ b/sm64-tas-scripting/pyramid.cpp
@@ -6,7 +6,7 @@
 #include "Trig.hpp"
 #include "Types.hpp"
 
-void simulate_platform_tilt(struct Object* marioObj, struct Object* pyramidPlatform, short* floorAngle, bool* isSlope) {
+bool simulate_platform_tilt(struct Object* marioObj, struct Object* pyramidPlatform, short* floorAngle, bool* isSlope) {
     Vec3f marioPos = { marioObj->oPosX, marioObj->oPosY, marioObj->oPosZ };
     struct Surface* pyramidSurfaces;
     int numSurfaces = get_surfaces(pyramidPlatform, &pyramidSurfaces);
@@ -31,11 +31,14 @@ void simulate_platform_tilt(struct Object* marioObj, struct Object* pyramidPlatf
         //Probably a better way of handling this
         *floorAngle = 0;
         *isSlope = false;
+        return false;
     }
     else {
         *floorAngle = atan2s(floor->normal.z, floor->normal.x);
         *isSlope = floor_is_slope(floor);
     }
+
+    return true;
 }
 
 void bhv_tilting_inverted_pyramid_loop(Vec3f& platNormal, Vec3f& platPos, Vec3f& marioPos, bool onPlatform, Mat4& transform) {

--- a/sm64-tas-scripting/pyramid.hpp
+++ b/sm64-tas-scripting/pyramid.hpp
@@ -4,7 +4,7 @@
 #ifndef PYRAMID_H
 #define PYRAMID_H
 
-void simulate_platform_tilt(struct Object* marioObj, struct Object* pyramidPlatform, short* floorAngle, bool* isSlope);
+bool simulate_platform_tilt(struct Object* marioObj, struct Object* pyramidPlatform, short* floorAngle, bool* isSlope);
 void bhv_tilting_inverted_pyramid_loop(Vec3f& platNormal, Vec3f& platPos, Vec3f& marioPos, bool onPlatform, Mat4& transform);
 float approach_by_increment(float goal, float src, float inc);
 void create_transform_from_normals(Mat4& transform, Vec3f& normal, Vec3f& pos);

--- a/sm64-tas-scripting/sm64-tas-scripting.vcxproj
+++ b/sm64-tas-scripting/sm64-tas-scripting.vcxproj
@@ -144,9 +144,11 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="BitFsPyramidOscillation.cpp" />
+    <ClCompile Include="BitFsPyramidOscillation_Iteration.cpp" />
     <ClCompile Include="BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp" />
     <ClCompile Include="BitFsPyramidOscillation_TurnThenRunDownhill.cpp" />
     <ClCompile Include="BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp" />
+    <ClCompile Include="BrakeToIdle.cpp" />
     <ClCompile Include="Game.cpp" />
     <ClCompile Include="GetMinimumDownhillWalkingAngle.cpp" />
     <ClCompile Include="Inputs.cpp" />

--- a/sm64-tas-scripting/sm64-tas-scripting.vcxproj.filters
+++ b/sm64-tas-scripting/sm64-tas-scripting.vcxproj.filters
@@ -75,6 +75,12 @@
     <ClCompile Include="surface.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="BrakeToIdle.cpp">
+      <Filter>Source Files\Scripts\General</Filter>
+    </ClCompile>
+    <ClCompile Include="BitFsPyramidOscillation_Iteration.cpp">
+      <Filter>Source Files\Scripts\BitFsPyramidOscillation</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Inputs.hpp">


### PR DESCRIPTION
-For smaller oscillations, Mario doesn't have enough running frames for the finish turning around action to expire before it's time to turn around again. This is a problem because you can't initiate another turnaround until Mario has transitioned back to the walking action (both actions have the same physics otherwise). So, Mario will have to run for extra frames before turning around again, which may produce a suboptimal path for the next oscillation.
-In this case, the alternative turnaround method of braking + quickturn may be competitive. Normally this takes more time to turn around, but that may not be the case for shorter oscillations. So, if the script detects that the regular turnaround path needed extra running frames to make finish turning around end, we want it to try braking/quickturn as well, compare the results, and apply the superior option.
-However, it's not that simple, because the braking/quickturn option is only available if Mario is already in the walking action. So instead, we have to go back to the PREVIOUS iteration and retry that with braking/quickturn, and then we can do a regular turnaround for the current iteration. At that point we compare the results and move forward with whatever is faster.
-I also fixed a bug with input targeting and made some other minor changes
