### PR TITLE
Rename methods for checking pre and post conditions

### DIFF
--- a/src/bin/bitfs-turnaround/src/main.cpp
+++ b/src/bin/bitfs-turnaround/src/main.cpp
@@ -29,7 +29,7 @@ class MainScript : public TopLevelScript
 public:
 	MainScript(M64& m64, Game* game) : TopLevelScript(m64, game) {}
 
-	bool verification() { return true; }
+	bool validation() { return true; }
 
 	bool execution()
 	{
@@ -39,7 +39,7 @@ public:
 		return true;
 	}
 
-	bool validation()
+	bool assertion()
 	{
 		// Save m64Diff to M64
 		for (auto& [frame, inputs]: BaseStatus.m64Diff.frames)

--- a/src/lib/tasfw-core/include/tasfw/Script.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.hpp
@@ -10,15 +10,15 @@ class Script;
 class BaseScriptStatus
 {
 public:
-	bool verified									= false;
+	bool validated									= false;
 	bool executed									= false;
-	bool validated								= false;
-	bool verificationThrew				= false;
+	bool asserted								= false;
+	bool validationThrew				= false;
 	bool executionThrew						= false;
-	bool validationThrew					= false;
-	uint64_t verificationDuration = 0;
+	bool assertionThrew					= false;
+	uint64_t validationDuration = 0;
 	uint64_t executionDuration		= 0;
-	uint64_t validationDuration		= 0;
+	uint64_t assertionDuration		= 0;
 	uint64_t nLoads								= 0;
 	uint64_t nSaves								= 0;
 	uint64_t nFrameAdvances				= 0;
@@ -85,8 +85,8 @@ protected:
 
 		TScript script = TScript(this, std::forward<Us>(params)...);
 
-		if (script.verify() && script.execute())
-			script.validate();
+		if (script.checkPreconditions() && script.execute())
+			script.checkPostconditions();
 
 		// Load if necessary
 		Revert(initialFrame, script.BaseStatus.m64Diff);
@@ -104,7 +104,7 @@ protected:
 	{
 		ScriptStatus<TScript> status =
 			Execute<TScript>(std::forward<Us>(params)...);
-		if (status.validated)
+		if (status.asserted)
 			Apply(status.m64Diff);
 
 		return status;
@@ -122,9 +122,9 @@ protected:
 		return status;
 	}
 
-	bool verify();
+	bool checkPreconditions();
 	bool execute();
-	bool validate();
+	bool checkPostconditions();
 
 	// TODO: move this method to some utility class
 	template <typename T>
@@ -143,9 +143,9 @@ protected:
 	void Load(uint64_t frame);
 	void Rollback(uint64_t frame);
 
-	virtual bool verification() = 0;
+	virtual bool validation() = 0;
 	virtual bool execution()		= 0;
-	virtual bool validation()		= 0;
+	virtual bool assertion()		= 0;
 
 private:
 	std::pair<uint64_t, Slot*> GetLatestSave(uint64_t frame);
@@ -172,16 +172,16 @@ public:
 
 		TTopLevelScript script = TTopLevelScript(m64, &game);
 
-		if (script.verify() && script.execute())
-			script.validate();
+		if (script.checkPreconditions() && script.execute())
+			script.checkPostconditions();
 
 		return ScriptStatus<TTopLevelScript>(
 			script.BaseStatus, script.CustomStatus);
 	}
 
-	virtual bool verification() override = 0;
+	virtual bool validation() override = 0;
 	virtual bool execution() override		 = 0;
-	virtual bool validation() override	 = 0;
+	virtual bool assertion() override	 = 0;
 
 	Inputs GetInputs(uint64_t frame) override;
 

--- a/src/lib/tasfw-core/src/Script.cpp
+++ b/src/lib/tasfw-core/src/Script.cpp
@@ -1,30 +1,30 @@
 #include <tasfw/Script.hpp>
 #include <chrono>
 
-bool Script::verify()
+bool Script::checkPreconditions()
 {
-	bool verified = false;
+	bool validated = false;
 
 	auto start = std::chrono::high_resolution_clock::now();
 	try
 	{
-		verified = verification();
+		validated = validation();
 	}
 	catch (exception& e)
 	{
-		BaseStatus.verificationThrew = true;
+		BaseStatus.validationThrew = true;
 	}
 	auto finish = std::chrono::high_resolution_clock::now();
 
-	BaseStatus.verificationDuration =
+	BaseStatus.validationDuration =
 		std::chrono::duration_cast<std::chrono::milliseconds>(finish - start)
 			.count();
 
-	// Revert state regardless of verification results
+	// Revert state regardless of validation results
 	Load(_initialFrame);
 
-	BaseStatus.verified = verified;
-	return verified;
+	BaseStatus.validated = validated;
+	return validated;
 }
 
 bool Script::execute()
@@ -54,30 +54,30 @@ bool Script::execute()
 	return executed;
 }
 
-bool Script::validate()
+bool Script::checkPostconditions()
 {
-	bool validated = false;
+	bool asserted = false;
 
 	auto start = std::chrono::high_resolution_clock::now();
 	try
 	{
-		validated = validation();
+		asserted = assertion();
 	}
 	catch (exception& e)
 	{
-		BaseStatus.validationThrew = true;
+		BaseStatus.assertionThrew = true;
 
-		// Revert state only if validation throws exception
+		// Revert state only if assertion throws exception
 		Load(_initialFrame);
 	}
 	auto finish = std::chrono::high_resolution_clock::now();
 
-	BaseStatus.validationDuration =
+	BaseStatus.assertionDuration =
 		std::chrono::duration_cast<std::chrono::milliseconds>(finish - start)
 			.count();
 
-	BaseStatus.validated = validated;
-	return validated;
+	BaseStatus.asserted = asserted;
+	return asserted;
 }
 
 Inputs TopLevelScript::GetInputs(uint64_t frame)

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/include/tasfw/scripts/BitFSPyramidOscillation.hpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/include/tasfw/scripts/BitFSPyramidOscillation.hpp
@@ -34,9 +34,9 @@ public:
 	BitFsPyramidOscillation(Script* parentScript, float targetXzSum, int quadrant)
 		: Script(parentScript), _targetXzSum(targetXzSum), _quadrant(quadrant) {}
 
-	bool verification();
-	bool execution();
 	bool validation();
+	bool execution();
+	bool assertion();
 
 private:
 	float _targetXzSum = 0;
@@ -64,9 +64,9 @@ public:
 	BitFsPyramidOscillation_Iteration(Script* parentScript, BitFsPyramidOscillation_ParamsDto oscillationParams, int32_t minFrame, int32_t maxFrame)
 		: Script(parentScript), _oscillationParams(oscillationParams), _minFrame(minFrame), _maxFrame(maxFrame) {}
 
-	bool verification();
-	bool execution();
 	bool validation();
+	bool execution();
+	bool assertion();
 
 private:
 	int32_t _minFrame = -1;
@@ -92,9 +92,9 @@ public:
 	BitFsPyramidOscillation_TurnThenRunDownhill(Script* parentScript, BitFsPyramidOscillation_ParamsDto oscillationParams)
 		: Script(parentScript), _oscillationParams(oscillationParams) {}
 
-	bool verification();
-	bool execution();
 	bool validation();
+	bool execution();
+	bool assertion();
 
 private:
 	BitFsPyramidOscillation_ParamsDto _oscillationParams;
@@ -122,9 +122,9 @@ public:
 		Script* parentScript, BitFsPyramidOscillation_ParamsDto oscillationParams, int16_t angle)
 		: Script(parentScript), _oscillationParams(oscillationParams), _angle(angle){}
 
-	bool verification();
-	bool execution();
 	bool validation();
+	bool execution();
+	bool assertion();
 
 private:
 	int16_t _angle;
@@ -151,9 +151,9 @@ public:
 		Script* parentScript, BitFsPyramidOscillation_ParamsDto oscillationParams)
 		: Script(parentScript), _oscillationParams(oscillationParams) {}
 
-	bool verification();
-	bool execution();
 	bool validation();
+	bool execution();
+	bool assertion();
 
 private:
 	BitFsPyramidOscillation_ParamsDto _oscillationParams;
@@ -184,9 +184,9 @@ public:
 	BitFsPyramidOscillation_RunDownhill(Script* parentScript, BitFsPyramidOscillation_ParamsDto oscillationParams)
 		: Script(parentScript), _oscillationParams(oscillationParams) {}
 
-	bool verification();
-	bool execution();
 	bool validation();
+	bool execution();
+	bool assertion();
 
 private:
 	BitFsPyramidOscillation_ParamsDto _oscillationParams;

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation.cpp
@@ -19,7 +19,7 @@ int16_t getRoughTargetNormal(
 	return iteration & 1 ? baseAngle + 0x8000 : baseAngle;
 }
 
-bool BitFsPyramidOscillation::verification()
+bool BitFsPyramidOscillation::validation()
 {
 	// Check if Mario is on the pyramid platform
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
@@ -74,7 +74,7 @@ bool BitFsPyramidOscillation::execution()
 	oscillationParams.roughTargetAngle = initAngleStatus.angleFacing;
 	auto initRunStatus =
 		Modify<BitFsPyramidOscillation_RunDownhill>(oscillationParams);
-	if (!initRunStatus.validated)
+	if (!initRunStatus.asserted)
 		return false;
 
 	// Record initial XZ sum, don't want to decrease this (TODO: optimize angle
@@ -111,7 +111,7 @@ bool BitFsPyramidOscillation::execution()
 		// diff that has the higher speed
 		if (i > 0 &&
 			(turnRunStatus.finishTurnaroundFailedToExpire ||
-			 !turnRunStatus.validated))
+			 !turnRunStatus.asserted))
 		{
 			M64Diff nonBrakeDiff	   = BaseStatus.m64Diff;
 			int64_t minFrameBrake	   = oscillationMinMaxFrames[i - 1].first;
@@ -125,7 +125,7 @@ bool BitFsPyramidOscillation::execution()
 			oscillationParamsPrev.initialXzSum = CustomStatus.finalXzSum[i & 1];
 			auto turnRunStatusBrake = Modify<BitFsPyramidOscillation_Iteration>(
 				oscillationParamsPrev, minFrameBrake, maxFrameBrake);
-			if (turnRunStatusBrake.validated)
+			if (turnRunStatusBrake.asserted)
 			{
 				int64_t minFrame2 =
 					turnRunStatusBrake.framePassedEquilibriumPoint;
@@ -151,7 +151,7 @@ bool BitFsPyramidOscillation::execution()
 
 		// Terminate when path fails to increase speed and XZ sum target has
 		// been reached in both directions
-		if (turnRunStatus.validated &&
+		if (turnRunStatus.asserted &&
 			(turnRunStatus.passedEquilibriumSpeed >
 				 CustomStatus.maxPassedEquilibriumSpeed[i & 1] ||
 			 CustomStatus.finalXzSum[(i & 1) ^ 1] < _targetXzSum ||
@@ -174,7 +174,7 @@ bool BitFsPyramidOscillation::execution()
 	return true;
 }
 
-bool BitFsPyramidOscillation::validation()
+bool BitFsPyramidOscillation::assertion()
 {
 	if (!BaseStatus.m64Diff.frames.size())
 		return false;

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_Iteration.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_Iteration.cpp
@@ -4,7 +4,7 @@
 #include <sm64/Sm64.hpp>
 #include <tasfw/Script.hpp>
 
-bool BitFsPyramidOscillation_Iteration::verification()
+bool BitFsPyramidOscillation_Iteration::validation()
 {
 	// Verify Mario is running on the platform
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
@@ -49,7 +49,7 @@ bool BitFsPyramidOscillation_Iteration::execution()
 		// we stop getting better results Once we get a valid result, we expect
 		// successive iterations to be worse (less space to accelerate), but
 		// that isn't always true
-		if (!status.validated)
+		if (!status.asserted)
 		{
 			if (turnRunStatus.passedEquilibriumSpeed == 0.0f)
 				continue;
@@ -64,7 +64,7 @@ bool BitFsPyramidOscillation_Iteration::execution()
 			break;
 	}
 
-	if (!turnRunStatus.validated)
+	if (!turnRunStatus.asserted)
 		return false;
 
 	CustomStatus.finalXzSum				= turnRunStatus.finalXzSum;
@@ -80,7 +80,7 @@ bool BitFsPyramidOscillation_Iteration::execution()
 	return true;
 }
 
-bool BitFsPyramidOscillation_Iteration::validation()
+bool BitFsPyramidOscillation_Iteration::assertion()
 {
 	if (BaseStatus.m64Diff.frames.empty())
 		return false;

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_RunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_RunDownhill.cpp
@@ -10,7 +10,7 @@
 
 #include <cmath>
 
-bool BitFsPyramidOscillation_RunDownhill::verification()
+bool BitFsPyramidOscillation_RunDownhill::validation()
 {
 	// Check if Mario is on the pyramid platform
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
@@ -88,7 +88,7 @@ bool BitFsPyramidOscillation_RunDownhill::execution()
 		// Record whether downhill angle attempt was successful + optimal
 		CustomScriptStatus::FrameInputStatus frameStatus;
 
-		if (!status.validated)
+		if (!status.asserted)
 			frameStatus.isAngleDownhill = false;
 		else if (marioState->faceAngle[1] == status.angleFacing)
 			frameStatus.isAngleDownhill = true;
@@ -161,7 +161,7 @@ bool BitFsPyramidOscillation_RunDownhill::execution()
 	return true;
 }
 
-bool BitFsPyramidOscillation_RunDownhill::validation()
+bool BitFsPyramidOscillation_RunDownhill::assertion()
 {
 	if (!BaseStatus.m64Diff.frames.size())
 		return false;

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
@@ -6,7 +6,7 @@
 #include <sm64/Types.hpp>
 #include <tasfw/Script.hpp>
 
-bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::verification()
+bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::validation()
 {
 	// Check if Mario is on the pyramid platform
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
@@ -45,7 +45,7 @@ bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::execution()
 		// Works with short oscialltion cycles, but takes an extra turnaround
 		// frame
 		auto status = Modify<BrakeToIdle>();
-		if (!status.validated)
+		if (!status.asserted)
 		{
 			CustomStatus.tooDownhill = (marioState->action == ACT_LAVA_BOOST);
 			return false;
@@ -114,7 +114,7 @@ bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::execution()
 	return true;
 }
 
-bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::validation()
+bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::assertion()
 {
 	return !BaseStatus.m64Diff.frames.empty();
 }

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill.cpp
@@ -6,7 +6,7 @@
 #include <sm64/Camera.hpp>
 #include <sm64/Sm64.hpp>
 
-bool BitFsPyramidOscillation_TurnThenRunDownhill::verification()
+bool BitFsPyramidOscillation_TurnThenRunDownhill::validation()
 {
 	// Verify Mario is running on the platform
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
@@ -55,7 +55,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill::execution()
 	{
 		auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle>(_oscillationParams, angle);
 
-		if (!status.validated)
+		if (!status.asserted)
 		{
 			if (status.tooDownhill)
 				break;
@@ -73,7 +73,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill::execution()
 	{
 		auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle>(_oscillationParams, angle);
 
-		if (!status.validated)
+		if (!status.asserted)
 		{
 			if (status.tooUphill)
 				break;
@@ -85,7 +85,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill::execution()
 			runStatus = status;
 	}
 
-	if (!runStatus.validated)
+	if (!runStatus.asserted)
 		return false;
 
 	CustomStatus.finalXzSum = runStatus.finalXzSum;
@@ -98,10 +98,10 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill::execution()
 
 	Apply(runStatus.m64Diff);
 
-	return runStatus.validated;
+	return runStatus.asserted;
 }
 
-bool BitFsPyramidOscillation_TurnThenRunDownhill::validation()
+bool BitFsPyramidOscillation_TurnThenRunDownhill::assertion()
 {
 	if (BaseStatus.m64Diff.frames.empty())
 		return false;

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
@@ -6,7 +6,7 @@
 #include <sm64/Camera.hpp>
 #include <sm64/Sm64.hpp>
 
-bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::verification()
+bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::validation()
 {
 	// Verify Mario is running on the platform
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
@@ -98,7 +98,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 		auto status = Execute<BitFsPyramidOscillation_TurnAroundAndRunDownhill>(_oscillationParams);
 
 		// Something weird happened, terminate
-		if (!status.validated)
+		if (!status.asserted)
 			break;
 
 		// We've gone too far uphill, terminate
@@ -122,7 +122,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 		AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
 	}
 
-	if (!runDownhillStatus.validated)
+	if (!runDownhillStatus.asserted)
 	{
 		// We want to record if these flags are set without any additional
 		// running frames This tells the caller that the angle paramter is
@@ -151,7 +151,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 	return true;
 }
 
-bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::validation()
+bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::assertion()
 {
 	if (BaseStatus.m64Diff.frames.empty())
 		return false;

--- a/src/lib/tasfw-scripts-general/include/tasfw/scripts/General.hpp
+++ b/src/lib/tasfw-scripts-general/include/tasfw/scripts/General.hpp
@@ -28,9 +28,9 @@ public:
 	{
 	}
 
-	bool verification();
-	bool execution();
 	bool validation();
+	bool execution();
+	bool assertion();
 
 private:
 	int16_t _faceAngle;
@@ -57,9 +57,9 @@ public:
 	{
 	}
 
-	bool verification();
-	bool execution();
 	bool validation();
+	bool execution();
+	bool assertion();
 
 private:
 	float _speed;
@@ -77,7 +77,7 @@ public:
 
 	BrakeToIdle(Script* parentScript) : Script(parentScript) {}
 
-	bool verification();
-	bool execution();
 	bool validation();
+	bool execution();
+	bool assertion();
 };

--- a/src/lib/tasfw-scripts-general/src/BrakeToIdle.cpp
+++ b/src/lib/tasfw-scripts-general/src/BrakeToIdle.cpp
@@ -5,7 +5,7 @@
 #include <sm64/Camera.hpp>
 #include <sm64/Sm64.hpp>
 
-bool BrakeToIdle::verification()
+bool BrakeToIdle::validation()
 {
 	// Check if Mario is on the pyramid platform
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
@@ -46,7 +46,7 @@ bool BrakeToIdle::execution()
 
 	// Quickturn uphill
 	auto status = Test<GetMinimumDownhillWalkingAngle>(marioState->faceAngle[1]);
-	if (!status.validated)
+	if (!status.asserted)
 		return false;
 
 	// Get closest cardinal controller input to uphill angle
@@ -70,7 +70,7 @@ bool BrakeToIdle::execution()
 	return true;
 }
 
-bool BrakeToIdle::validation()
+bool BrakeToIdle::assertion()
 {
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
 	if (marioState->action != ACT_IDLE)

--- a/src/lib/tasfw-scripts-general/src/GetMinimumDownhillWalkingAngle.cpp
+++ b/src/lib/tasfw-scripts-general/src/GetMinimumDownhillWalkingAngle.cpp
@@ -6,7 +6,7 @@
 #include <sm64/Pyramid.hpp>
 #include <sm64/Surface.hpp>
 
-bool GetMinimumDownhillWalkingAngle::verification()
+bool GetMinimumDownhillWalkingAngle::validation()
 {
 	// Check if Mario is on the pyramid platform
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
@@ -42,7 +42,7 @@ bool GetMinimumDownhillWalkingAngle::execution()
 	{
 			auto status = Test<TryHackedWalkOutOfBounds>(walkSpeed);
 
-			if (status.validated)
+			if (status.asserted)
 			{
 					hackedWalkValidated = true;
 					floorAngle = status.floorAngle;
@@ -111,7 +111,7 @@ bool GetMinimumDownhillWalkingAngle::execution()
 	return true;
 }
 
-bool GetMinimumDownhillWalkingAngle::validation()
+bool GetMinimumDownhillWalkingAngle::assertion()
 {
 	return CustomStatus.isSlope;
 }

--- a/src/lib/tasfw-scripts-general/src/TryHackedWalkOutOfBounds.cpp
+++ b/src/lib/tasfw-scripts-general/src/TryHackedWalkOutOfBounds.cpp
@@ -8,7 +8,7 @@
 
 #include <cmath>
 
-bool TryHackedWalkOutOfBounds::verification()
+bool TryHackedWalkOutOfBounds::validation()
 {
 	return true;
 }
@@ -36,7 +36,7 @@ bool TryHackedWalkOutOfBounds::execution()
 	return true;
 }
 
-bool TryHackedWalkOutOfBounds::validation()
+bool TryHackedWalkOutOfBounds::assertion()
 {
 	float hDistMoved = sqrtf(
 		pow(CustomStatus.endPos[0] - CustomStatus.startPos[0], 2) +


### PR DESCRIPTION
See https://github.com/TylerKehne/sm64-tas-scripting/issues/15. Since assert() is a reserved methods in C, I used checkPreconditions() and checkPostconditions() in the Script class but the derived classes use validation() and assertion() as I feel these words are simpler