### PR TITLE
Improve performance of Modify() method

### DIFF
--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation.cpp
@@ -86,7 +86,7 @@ bool BitFsPyramidOscillation::execution()
 	// as possible, without sacrificing XZ sum
 	uint64_t minFrame = initRunStatus.framePassedEquilibriumPoint == -1 ?
 		initRunStatus.m64Diff.frames.begin()->first :
-		  initRunStatus.framePassedEquilibriumPoint;
+		initRunStatus.framePassedEquilibriumPoint;
 	uint64_t maxFrame = initRunStatus.m64Diff.frames.rbegin()->first;
 	CustomStatus.finalXzSum[1] = initRunStatus.finalXzSum;
 	vector<std::pair<int64_t, int64_t>> oscillationMinMaxFrames;


### PR DESCRIPTION
Addresses https://github.com/TylerKehne/sm64-tas-scripting/issues/18

Previously, Modify() would simply run Execute(), which always reverts the game back to the previous state, and then Apply(), which applies the child script's diff to the parent, and forwards the game's state to the end of the diff.

However, this doesn't take advantage of the fact that the game's state upon executing the child script is already synced with the child script's diff, and reverting it is unnecessary, provided the script asserts and generates a diff. The new Modify() method accounts for this by simply copying the diff over and then loading state at the end of the diff, resulting in a significant performance improvement that achieves the same output as the previous method.