### PR TITLE
General cleanups

### DIFF
--- a/src/bin/bitfs-turnaround/src/BitFsConfig.cpp
+++ b/src/bin/bitfs-turnaround/src/BitFsConfig.cpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 
 #if defined(_WIN32)
+#define NOMINMAX
 	#include <windows.h>
 const std::filesystem::path& getPathToSelf()
 {

--- a/src/bin/bitfs-turnaround/src/BitFsConfig.cpp
+++ b/src/bin/bitfs-turnaround/src/BitFsConfig.cpp
@@ -17,7 +17,8 @@ const std::filesystem::path& getPathToSelf()
 		if (res == 0) {
 			throw std::system_error(GetLastError(), std::system_category());
 		}
-		return buffer.get();
+		std::filesystem::path path(buffer.get());
+		return path;
 	}();
 	return cached;
 }
@@ -33,7 +34,8 @@ const std::filesystem::path& getPathToSelf()
 			throw std::system_error(res, std::generic_category());
 		}
 		std::cout << "Retrieved self path: " << buffer.get() << '\n';
-		return buffer.get();
+		std::filesystem::path path(buffer.get());
+		return path;
 	}();
 	return cached;
 }

--- a/src/bin/bitfs-turnaround/src/BitFsConfig.hpp
+++ b/src/bin/bitfs-turnaround/src/BitFsConfig.hpp
@@ -1,5 +1,4 @@
 #include <filesystem>
-#include <nlohmann/json.hpp>
 
 const std::filesystem::path& getPathToSelf();
 

--- a/src/lib/tasfw-core/CMakeLists.txt
+++ b/src/lib/tasfw-core/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(tasfw-core
 )
 target_compile_features(tasfw-core PUBLIC cxx_std_20)
 target_include_directories(tasfw-core PUBLIC include)
-target_link_libraries(tasfw-core PUBLIC tasfw::decomp)
+target_link_libraries(tasfw-core PUBLIC tasfw::decomp ${CMAKE_DL_LIBS})
 
 include(MatchArchFlag)
 match_arch_and_ipo(tasfw-core)

--- a/src/lib/tasfw-core/include/tasfw/Game.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Game.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <string.h>
+#include <cstring>
 #include <iostream>
-#include <unordered_map>
 #include <vector>
 
 #include <tasfw/Inputs.hpp>
@@ -12,13 +11,11 @@
 #ifndef GAME_H
 	#define GAME_H
 
-using namespace std;
-
 // structs like this can be aggregate-initialized
 // like SegVal {".data", 0xDEADBEEF, 12345678};
 struct SegVal
 {
-	string name;
+	std::string name;
 	void* address;
 	size_t length;
 
@@ -36,8 +33,8 @@ class Slot
 public:
 	std::vector<uint8_t> buf1;
 	std::vector<uint8_t> buf2;
-	Game* game = NULL;
-	Script* script = NULL;
+	Game* game = nullptr;
+	Script* script = nullptr;
 	int64_t frame = -1;
 
 	Slot() = default;
@@ -121,7 +118,7 @@ public:
 	void load_state(int64_t slotId);
 	void* addr(const char* symbol);
 	uint32_t getCurrentFrame();
-	bool shouldSave(uint64_t framesSinceLastSave);
+	bool shouldSave(uint64_t framesSinceLastSave) const;
 
 private:
 	friend class Slot;

--- a/src/lib/tasfw-core/include/tasfw/Inputs.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Inputs.hpp
@@ -2,7 +2,6 @@
 #include <cstdint>
 #include <filesystem>
 #include <map>
-#include <vector>
 
 #ifndef INPUTS_H
 	#define INPUTS_H
@@ -24,12 +23,14 @@ public:
 
 	Rotation Negate()
 	{
-		if (value == Rotation::CLOCKWISE)
-			return Rotation::COUNTERCLOCKWISE;
-		else if (value == Rotation::COUNTERCLOCKWISE)
-			return Rotation::CLOCKWISE;
-
-		return Rotation::NONE;
+		switch (value) {
+			case Rotation::CLOCKWISE:
+				return Rotation::COUNTERCLOCKWISE;
+			case Rotation::COUNTERCLOCKWISE:
+				return Rotation::CLOCKWISE;
+			case Rotation::NONE:
+				return Rotation::NONE;
+		}
 	}
 
 private:
@@ -38,20 +39,20 @@ private:
 
 enum Buttons
 {
-	C_RIGHT = 1 << 0,
-	C_LEFT	= 1 << 1,
-	C_DOWN	= 1 << 2,
-	C_UP		= 1 << 3,
-	R				= 1 << 4,
-	L				= 1 << 5,
-	D_RIGHT = 1 << 8,
-	D_LEFT	= 1 << 9,
-	D_DOWN	= 1 << 10,
-	D_UP		= 1 << 11,
-	START		= 1 << 12,
-	Z				= 1 << 13,
-	B				= 1 << 14,
-	A				= 1 << 15
+	C_RIGHT = 1U << 0U,
+	C_LEFT	= 1U << 1U,
+	C_DOWN	= 1U << 2U,
+	C_UP		= 1U << 3U,
+	R				= 1U << 4U,
+	L				= 1U << 5U,
+	D_RIGHT = 1U << 8U,
+	D_LEFT	= 1U << 9U,
+	D_DOWN	= 1U << 10U,
+	D_UP		= 1U << 11U,
+	START		= 1U << 12U,
+	Z				= 1U << 13U,
+	B				= 1U << 14U,
+	A				= 1U << 15U
 };
 
 class Inputs
@@ -61,7 +62,7 @@ public:
 	int8_t stick_x	 = 0;
 	int8_t stick_y	 = 0;
 
-	Inputs() {}
+	Inputs() = default;
 
 	Inputs(uint16_t buttons, int8_t stick_x, int8_t stick_y) :
 		buttons(buttons), stick_x(stick_x), stick_y(stick_y)
@@ -84,7 +85,7 @@ class M64Base
 public:
 	std::map<uint64_t, Inputs> frames;
 
-	M64Base() {}
+	M64Base() = default;
 };
 
 class M64 : public M64Base
@@ -92,9 +93,9 @@ class M64 : public M64Base
 public:
 	std::filesystem::path fileName;
 
-	M64() {}
+	M64() = default;
 
-	M64(const std::filesystem::path& fileName) : fileName(fileName) {}
+	M64(std::filesystem::path fileName) : fileName(std::move(fileName)) {}
 
 	int load();
 	int save(long initFrame = 0);
@@ -103,7 +104,7 @@ public:
 class M64Diff : public M64Base
 {
 public:
-	M64Diff() : M64Base() {}
+	M64Diff() = default;
 };
 
 #endif

--- a/src/lib/tasfw-core/include/tasfw/Script.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.hpp
@@ -26,7 +26,7 @@ public:
 	uint64_t nFrameAdvances = 0;
 	M64Diff m64Diff = M64Diff();
 
-	BaseScriptStatus() {}
+	BaseScriptStatus() = default;
 };
 
 template <std::derived_from<Script> TScript>
@@ -57,11 +57,10 @@ public:
 	BaseScriptStatus BaseStatus;
 	Script* _parentScript;
 	std::map<uint64_t, SlotHandle> saveBank;
-	Game* game = NULL;
+	Game* game = nullptr;
 
-	Script(Script* parentScript)
+	Script(Script* parentScript) : _parentScript(parentScript)
 	{
-		_parentScript = parentScript;
 		if (_parentScript)
 		{
 			game					= _parentScript->game;
@@ -196,7 +195,7 @@ private:
 class TopLevelScript : public Script
 {
 public:
-	TopLevelScript(M64& m64, Game* game) : Script(NULL), _m64(m64)
+	TopLevelScript(M64& m64, Game* game) : Script(nullptr), _m64(m64)
 	{
 		this->game = game;
 	}

--- a/src/lib/tasfw-core/include/tasfw/SharedLib.hpp
+++ b/src/lib/tasfw-core/include/tasfw/SharedLib.hpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #if defined(_WIN32)
+#define NOMINMAX
 	#include <windows.h>
 
 	#define TAS_FW_STDCALL __stdcall

--- a/src/lib/tasfw-core/src/Game.cpp
+++ b/src/lib/tasfw-core/src/Game.cpp
@@ -69,7 +69,7 @@ int64_t SlotManager::CreateSlot(Script* script, int64_t frame)
 		}
 
 		if (slotsById.size() == 0)
-			throw std::exception("Not enough game slot memory allocated");
+			throw std::runtime_error("Not enough game slot memory allocated");
 
 		// If save memory is full, remove the earliest save and try again
 		EraseOldestSlot();
@@ -143,7 +143,7 @@ void Game::save_state_initial()
 
 	int64_t additionalMem = segment[0].length + segment[1].length;
 	if (_currentSaveMem + additionalMem > _saveMemLimit)
-		throw std::exception("Not enough game slot memory allocated");
+		throw std::runtime_error("Not enough game slot memory allocated");
 
 	startSave.buf1.resize(segment[0].length);
 	startSave.buf2.resize(segment[1].length);
@@ -188,7 +188,7 @@ uint32_t Game::getCurrentFrame()
 	return *(uint32_t*) (addr("gGlobalTimer")) - 1;
 }
 
-bool Game::shouldSave(uint64_t framesSinceLastSave)
+bool Game::shouldSave(uint64_t framesSinceLastSave) const
 {
 	double estTimeToSave = double(_totalSaveStateTime) / nSaveStates;
 	double estTimeToLoadFromRecent =

--- a/src/lib/tasfw-core/src/Inputs.cpp
+++ b/src/lib/tasfw-core/src/Inputs.cpp
@@ -17,7 +17,7 @@
 
 static uint16_t byteswap(uint16_t x)
 {
-	return (x >> 8) | (x << 8);
+	return (x >> 8U) | (x << 8U);
 }
 
 
@@ -394,7 +394,7 @@ int M64::save(long initFrame)
 			int8_t stickX							= 0;
 			int8_t stickY							= 0;
 
-			if (frames.count(i))
+			if (frames.contains(i))
 			{
 				bigEndianButtons = byteswap(frames[i].buttons);
 				stickX					 = frames[i].stick_x;

--- a/src/lib/tasfw-core/src/SharedLib.cpp
+++ b/src/lib/tasfw-core/src/SharedLib.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 
 #if defined(_WIN32)
+#define NOMINMAX
 	#include <windows.h>
 
 SharedLib::SharedLib(const std::filesystem::path& fileName) :

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation.cpp
@@ -16,7 +16,7 @@ int16_t getRoughTargetNormal(
 	int16_t baseAngle	  = quadrant * 0x4000 - 0x2000 + 0x4000;
 	int16_t initAngleDiff = baseAngle - initWalkingAngle;
 	baseAngle = abs(initAngleDiff) < 0x4000 ? baseAngle + 0x8000 : baseAngle;
-	return iteration & 1 ? baseAngle + 0x8000 : baseAngle;
+	return iteration & 1U ? baseAngle + 0x8000 : baseAngle;
 }
 
 bool BitFsPyramidOscillation::validation()
@@ -89,19 +89,19 @@ bool BitFsPyramidOscillation::execution()
 		initRunStatus.framePassedEquilibriumPoint;
 	uint64_t maxFrame = initRunStatus.m64Diff.frames.rbegin()->first;
 	CustomStatus.finalXzSum[1] = initRunStatus.finalXzSum;
-	vector<std::pair<int64_t, int64_t>> oscillationMinMaxFrames;
+	std::vector<std::pair<int64_t, int64_t>> oscillationMinMaxFrames;
 	for (int i = 0; i < 200; i++)
 	{
-		oscillationMinMaxFrames.push_back({minFrame, maxFrame});
+		oscillationMinMaxFrames.emplace_back(minFrame, maxFrame);
 
 		// Start at the latest ppossible frame and work backwards. Stop when the
 		// max speed at the equilibrium point stops increasing.
 		oscillationParams = baseOscParams;
 		oscillationParams.roughTargetNormal =
 			getRoughTargetNormal(_quadrant, i, initAngle);
-		oscillationParams.prevMaxSpeed = CustomStatus.maxSpeed[i & 1];
+		oscillationParams.prevMaxSpeed = CustomStatus.maxSpeed[i & 1U];
 		oscillationParams.brake		   = false;
-		oscillationParams.initialXzSum = CustomStatus.finalXzSum[(i & 1) ^ 1];
+		oscillationParams.initialXzSum = CustomStatus.finalXzSum[(i & 1U) ^ 1U];
 		auto turnRunStatus = Execute<BitFsPyramidOscillation_Iteration>(
 			oscillationParams, minFrame, maxFrame);
 
@@ -120,9 +120,9 @@ bool BitFsPyramidOscillation::execution()
 			oscillationParamsPrev.roughTargetNormal =
 				getRoughTargetNormal(_quadrant, i - 1, initAngle);
 			oscillationParamsPrev.prevMaxSpeed =
-				CustomStatus.maxSpeed[(i & 1) ^ 1];
+				CustomStatus.maxSpeed[(i & 1U) ^ 1U];
 			oscillationParamsPrev.brake		   = true;
-			oscillationParamsPrev.initialXzSum = CustomStatus.finalXzSum[i & 1];
+			oscillationParamsPrev.initialXzSum = CustomStatus.finalXzSum[i & 1U];
 			auto turnRunStatusBrake = Modify<BitFsPyramidOscillation_Iteration>(
 				oscillationParamsPrev, minFrameBrake, maxFrameBrake);
 			if (turnRunStatusBrake.asserted)
@@ -140,7 +140,7 @@ bool BitFsPyramidOscillation::execution()
 					oscillationMinMaxFrames[i - 1] = {
 						minFrameBrake, maxFrameBrake};
 					oscillationMinMaxFrames[i] = {minFrame2, maxFrame2};
-					CustomStatus.maxSpeed[(i & 1)] =
+					CustomStatus.maxSpeed[(i & 1U)] =
 						turnRunStatusBrake.speedBeforeTurning;
 					turnRunStatus = turnRunStatus2;
 				}

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_Iteration.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_Iteration.cpp
@@ -82,8 +82,5 @@ bool BitFsPyramidOscillation_Iteration::execution()
 
 bool BitFsPyramidOscillation_Iteration::assertion()
 {
-	if (BaseStatus.m64Diff.frames.empty())
-		return false;
-
-	return true;
+	return !BaseStatus.m64Diff.frames.empty();
 }

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_RunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_RunDownhill.cpp
@@ -163,8 +163,5 @@ bool BitFsPyramidOscillation_RunDownhill::execution()
 
 bool BitFsPyramidOscillation_RunDownhill::assertion()
 {
-	if (!BaseStatus.m64Diff.frames.size())
-		return false;
-
-	return true;
+	return !BaseStatus.m64Diff.frames.empty();
 }

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
@@ -72,7 +72,7 @@ bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::execution()
 				AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
 
 				if ((marioState->action != ACT_WALKING) ||
-					marioState->floor->object == NULL ||
+					marioState->floor->object == nullptr ||
 					marioState->floor->object->behavior != pyramidBehavior)
 					return false;
 
@@ -90,10 +90,10 @@ bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::execution()
 				return false;
 			}
 
-			if (marioState->floor->object == NULL ||
+			if (marioState->floor->object == nullptr ||
 				marioState->floor->object->behavior != pyramidBehavior)
 			{
-				CustomStatus.tooDownhill = (marioState->floor->object == NULL);
+				CustomStatus.tooDownhill = (marioState->floor->object == nullptr);
 				return false;
 			}
 		} while (marioState->action == ACT_TURNING_AROUND);

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill.cpp
@@ -44,7 +44,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill::execution()
 	//Get range of target turning around angles to test
 	auto hillStatus = Test<GetMinimumDownhillWalkingAngle>(marioState->faceAngle[1]);
 	Rotation downhillRotation = hillStatus.downhillRotation == Rotation::CLOCKWISE ? Rotation::CLOCKWISE : Rotation::COUNTERCLOCKWISE;
-	int32_t extremeDownhillHau = hillStatus.angleFacing - (hillStatus.angleFacing & 15);
+	int32_t extremeDownhillHau = hillStatus.angleFacing - (hillStatus.angleFacing & 15U);
 	int32_t extremeUphillHau = extremeDownhillHau - 0x4000 * (int)downhillRotation;
 	int32_t midHau = (extremeDownhillHau + extremeUphillHau) / 2;
 

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
@@ -62,7 +62,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 		if (
 			(marioState->action != ACT_WALKING &&
 			 marioState->action != ACT_FINISH_TURNING_AROUND) ||
-			marioState->floor->object == NULL ||
+			marioState->floor->object == nullptr ||
 			marioState->floor->object->behavior != pyramidBehavior)
 			return false;
 

--- a/src/lib/tasfw-scripts-general/src/BrakeToIdle.cpp
+++ b/src/lib/tasfw-scripts-general/src/BrakeToIdle.cpp
@@ -73,8 +73,5 @@ bool BrakeToIdle::execution()
 bool BrakeToIdle::assertion()
 {
 	MarioState* marioState = (MarioState*) (game->addr("gMarioStates"));
-	if (marioState->action != ACT_IDLE)
-		return false;
-
-	return true;
+	return marioState->action == ACT_IDLE;
 }

--- a/src/lib/tasfw-scripts-general/src/GetMinimumDownhillWalkingAngle.cpp
+++ b/src/lib/tasfw-scripts-general/src/GetMinimumDownhillWalkingAngle.cpp
@@ -21,10 +21,7 @@ bool GetMinimumDownhillWalkingAngle::validation()
 
 	const BehaviorScript* pyramidBehavior =
 		(const BehaviorScript*) (game->addr("bhvBitfsTiltingInvertedPyramid"));
-	if (floorObject->behavior != pyramidBehavior)
-		return false;
-
-	return true;
+	return floorObject->behavior == pyramidBehavior;
 }
 
 bool GetMinimumDownhillWalkingAngle::execution()

--- a/src/lib/tasfw-scripts-general/src/TryHackedWalkOutOfBounds.cpp
+++ b/src/lib/tasfw-scripts-general/src/TryHackedWalkOutOfBounds.cpp
@@ -41,11 +41,8 @@ bool TryHackedWalkOutOfBounds::assertion()
 	float hDistMoved = sqrtf(
 		pow(CustomStatus.endPos[0] - CustomStatus.startPos[0], 2) +
 		pow(CustomStatus.endPos[2] - CustomStatus.startPos[2], 2));
-	if (hDistMoved >= abs(_speed * 0.01f))
+	if (hDistMoved >= std::abs(_speed * 0.01f))
 		return false;
 
-	if (CustomStatus.endAction != ACT_WALKING)
-		return false;
-
-	return true;
+	return CustomStatus.endAction == ACT_WALKING;
 }


### PR DESCRIPTION
const std::filesystem::path& getPathToSelf()
{
    static std::filesystem::path cached = [&] {
        auto buffer = std::unique_ptr<char[]>(new char[PATH_MAX + 1]());
        ssize_t res = readlink("/proc/self/exe", buffer.get(), PATH_MAX);
        if (res < 0) {
            throw std::system_error(res, std::generic_category());
        }
        std::cout << "Retrieved self path: " << buffer.get() << '\n';
        return buffer.get();
    }();
    return cached;
}
had a use after free error since buffer is a unique pointer so the allocation is freed when it goes out of scope, .get, just returns you the raw pointer, but the memory block should still go out of scope and be freed

don't include extra includes in header

cstring is the modern form of string.h

don't use "using namespace std;" in a header it pollutes the global namespace

use "= default" for trivial constructors and destructors

nullptr over NULL

bit manipulcation should always use unsigned numbers

use contains for maps and sets to check membership

use empty instead of size to check if its empty