### PR TITLE
Compare frame advance performance with future load

### DIFF
--- a/src/lib/tasfw-core/include/tasfw/Game.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Game.hpp
@@ -118,7 +118,8 @@ public:
 	void load_state(int64_t slotId);
 	void* addr(const char* symbol);
 	uint32_t getCurrentFrame();
-	bool shouldSave(uint64_t framesSinceLastSave) const;
+	bool shouldSave(int64_t framesSinceLastSave) const;
+	bool shouldLoad(int64_t framesAhead) const;
 
 private:
 	friend class Slot;

--- a/src/lib/tasfw-core/src/Game.cpp
+++ b/src/lib/tasfw-core/src/Game.cpp
@@ -188,12 +188,27 @@ uint32_t Game::getCurrentFrame()
 	return *(uint32_t*) (addr("gGlobalTimer")) - 1;
 }
 
-bool Game::shouldSave(uint64_t framesSinceLastSave) const
+bool Game::shouldSave(int64_t framesSinceLastSave) const
 {
+	if (nSaveStates == 0 || framesSinceLastSave < 0)
+		return true;
+
 	double estTimeToSave = double(_totalSaveStateTime) / nSaveStates;
 	double estTimeToLoadFromRecent =
 		(double(_totalFrameAdvanceTime) / nFrameAdvances) * framesSinceLastSave;
 
 	// TODO: Reduce number of automatic load states in script
-	return estTimeToSave <= 2 * estTimeToLoadFromRecent;
+	return estTimeToSave < 2 * estTimeToLoadFromRecent;
+}
+
+bool Game::shouldLoad(int64_t framesAhead) const
+{
+	if (nLoadStates == 0 || framesAhead < 0)
+		return true;
+
+	double estTimeToLoad = double(_totalLoadStateTime) / nLoadStates;
+	double estTimeToFrameAdvance =
+		(double(_totalFrameAdvanceTime) / nFrameAdvances) * framesAhead;
+
+	return estTimeToLoad < framesAhead;
 }


### PR DESCRIPTION
If loading a future frame, it may be faster to load a future save if one is available. Load() and Revert() now check for this. I decided not to have AdvanceFrameRead() check for this, as I think it's unlikely that load state will be faster than frame advance for most Game implementations, and on top of that there would have to be a save state on that frame. Might revisit that in the future though.