### PR TITLE
Implement Ad-hoc scripts and Compare() methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,11 @@
   "editor.insertSpaces": false,
   "editor.tabSize": 4,
   "files.associations": {
-    "chrono": "cpp"
+    "chrono": "cpp",
+    "vector": "cpp",
+    "xtree": "cpp",
+    "algorithm": "cpp",
+    "xhash": "cpp",
+    "utility": "cpp"
   }
 }

--- a/src/bin/bitfs-turnaround/src/main.cpp
+++ b/src/bin/bitfs-turnaround/src/main.cpp
@@ -42,7 +42,8 @@ public:
 	bool assertion()
 	{
 		// Save m64Diff to M64
-		for (auto& [frame, inputs]: BaseStatus.m64Diff.frames)
+		M64Diff diff = GetDiff();
+		for (auto& [frame, inputs]: diff.frames)
 		{
 			_m64.frames[frame] = inputs;
 		}

--- a/src/lib/tasfw-core/include/tasfw/Game.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Game.hpp
@@ -35,11 +35,13 @@ public:
 	std::vector<uint8_t> buf2;
 	Game* game = nullptr;
 	Script* script = nullptr;
+	int64_t adhocLevel = -1;
 	int64_t frame = -1;
 
 	Slot() = default;
 
-	Slot(Game* game, Script* script, int64_t frame) : game(game), script(script), frame(frame) { }
+	Slot(Game* game, Script* script, int64_t frame, int64_t adhocLevel)
+		: game(game), script(script), frame(frame), adhocLevel(adhocLevel) { }
 
 	~Slot();
 };
@@ -68,7 +70,7 @@ private:
 
 	SlotManager(Game* game) : _game(game) { }
 
-	int64_t CreateSlot(Script* script, int64_t frame);
+	int64_t CreateSlot(Script* script, int64_t frame, int64_t adhocLevel);
 	void EraseOldestSlot();
 	void EraseSlot(int64_t slotId);
 	void UpdateSlot(int64_t slotId);
@@ -114,7 +116,7 @@ public:
 
 	void advance_frame();
 	void save_state_initial();
-	int64_t save_state(Script* script, int64_t frame);
+	int64_t save_state(Script* script, int64_t frame, int64_t adhocLevel);
 	void load_state(int64_t slotId);
 	void* addr(const char* symbol);
 	uint32_t getCurrentFrame();

--- a/src/lib/tasfw-core/src/Game.cpp
+++ b/src/lib/tasfw-core/src/Game.cpp
@@ -39,7 +39,7 @@ SlotHandle::~SlotHandle()
 		game->slotManager.EraseSlot(slotId);
 }
 
-int64_t SlotManager::CreateSlot(Script* script, int64_t frame)
+int64_t SlotManager::CreateSlot(Script* script, int64_t frame, int64_t adhocLevel)
 {
 	while (true)
 	{
@@ -48,7 +48,7 @@ int64_t SlotManager::CreateSlot(Script* script, int64_t frame)
 		{
 			//NOTE: IDs/Order will not overflow on realistic timescales
 			int64_t slotId = slotsById.size() == 0 ? 0 : std::prev(slotsById.end())->first + 1;
-			slotsById[slotId] = Slot(_game, script, frame);
+			slotsById[slotId] = Slot(_game, script, frame, adhocLevel);
 			int64_t slotOrder = slotIdsByLastAccess.size() == 0 ? 0 : std::prev(slotIdsByLastAccess.end())->first + 1;
 			slotIdsByLastAccess[slotOrder] = slotId;
 			slotLastAccessOrderById[slotId] = slotOrder;
@@ -105,7 +105,7 @@ void SlotManager::EraseOldestSlot()
 		return;
 
 	//Remove slot handle from script hierarchy, triggering slot deletion
-	slotsById[slotId].script->DeleteSave(slotsById[slotId].frame);
+	slotsById[slotId].script->DeleteSave(slotsById[slotId].frame, slotsById[slotId].adhocLevel);
 }
 
 void Game::advance_frame()
@@ -126,10 +126,10 @@ void Game::advance_frame()
 	nFrameAdvances++;
 }
 
-int64_t Game::save_state(Script* script, int64_t frame)
+int64_t Game::save_state(Script* script, int64_t frame, int64_t adhocLevel)
 {
 	auto start = get_time();
-	int64_t slotId = slotManager.CreateSlot(script, frame);
+	int64_t slotId = slotManager.CreateSlot(script, frame, adhocLevel);
 	_totalSaveStateTime += get_time() - start;
 
 	nSaveStates++;

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/include/tasfw/scripts/BitFSPyramidOscillation.hpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/include/tasfw/scripts/BitFSPyramidOscillation.hpp
@@ -51,13 +51,13 @@ public:
 	class CustomScriptStatus
 	{
 	public:
-		float initialXzSum									= 0;
-		float finalXzSum										= 0;
-		float maxSpeed											= 0;
-		float passedEquilibriumSpeed				= 0;
+		float initialXzSum = 0;
+		float finalXzSum = 0;
+		float maxSpeed = 0;
+		float passedEquilibriumSpeed = 0;
 		int64_t framePassedEquilibriumPoint = -1;
 		bool finishTurnaroundFailedToExpire = false;
-		float speedBeforeTurning						= 0;
+		float speedBeforeTurning = 0;
 	};
 	CustomScriptStatus CustomStatus = CustomScriptStatus();
 
@@ -80,10 +80,10 @@ public:
 	class CustomScriptStatus
 	{
 	public:
-		float initialXzSum									= 0;
-		float finalXzSum										= 0;
-		float maxSpeed											= 0;
-		float passedEquilibriumSpeed				= 0;
+		float initialXzSum = 0;
+		float finalXzSum = 0;
+		float maxSpeed = 0;
+		float passedEquilibriumSpeed = 0;
 		int64_t framePassedEquilibriumPoint = -1;
 		bool finishTurnaroundFailedToExpire = false;
 	};
@@ -107,13 +107,13 @@ public:
 	{
 	public:
 		int64_t framePassedEquilibriumPoint = -1;
-		float initialXzSum									= 0;
-		float finalXzSum										= 0;
-		float maxSpeed											= 0;
-		float passedEquilibriumSpeed				= 0;
-		bool tooSlowForTurnAround						= false;
-		bool tooUphill											= false;
-		bool tooDownhill										= false;
+		float initialXzSum = 0;
+		float finalXzSum = 0;
+		float maxSpeed = 0;
+		float passedEquilibriumSpeed = 0;
+		bool tooSlowForTurnAround = false;
+		bool tooUphill = false;
+		bool tooDownhill = false;
 		bool finishTurnaroundFailedToExpire = false;
 	};
 	CustomScriptStatus CustomStatus = CustomScriptStatus();
@@ -138,11 +138,11 @@ public:
 	{
 	public:
 		int64_t framePassedEquilibriumPoint = -1;
-		float maxSpeed											= 0;
-		float passedEquilibriumSpeed				= 0;
-		float finalXzSum										= 0;
-		bool tooDownhill										= false;
-		bool tooUphill											= false;
+		float maxSpeed = 0;
+		float passedEquilibriumSpeed = 0;
+		float finalXzSum = 0;
+		bool tooDownhill = false;
+		bool tooUphill = false;
 		bool finishTurnaroundFailedToExpire = false;
 	};
 	CustomScriptStatus CustomStatus = CustomScriptStatus();
@@ -169,7 +169,7 @@ public:
 		{
 		public:
 			bool isAngleDownhill = false;
-			bool isAngleOptimal	 = false;
+			bool isAngleOptimal = false;
 		};
 
 		std::map<uint64_t, FrameInputStatus> frameStatuses;

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation.cpp
@@ -85,6 +85,28 @@ bool BitFsPyramidOscillation::execution()
 		[&](CompareJumpStatus& customStatus) {
 			AdvanceFrameWrite(Inputs(Buttons::A, 0, 0));
 			customStatus.y = marioState->pos[1];
+
+			auto compareStatus2 = Compare<CompareJumpStatus>(
+				[&](CompareJumpStatus& customStatus2) {
+					AdvanceFrameWrite(Inputs(Buttons::A, 0, 0));
+					customStatus2.y = marioState->pos[1];
+					return true;
+				},
+				[&](CompareJumpStatus& customStatus2) {
+					AdvanceFrameWrite(Inputs(Buttons::A, 0, 0));
+					AdvanceFrameWrite(Inputs(Buttons::A, 0, 0));
+					customStatus2.y = marioState->pos[1];
+					return true;
+				},
+					[&](CompareJumpStatus& customStatus2) {
+					AdvanceFrameWrite(Inputs(Buttons::A, 0, 0));
+					AdvanceFrameWrite(Inputs(Buttons::A, 0, 0));
+					AdvanceFrameWrite(Inputs(Buttons::A, 0, 0));
+					customStatus2.y = marioState->pos[1];
+					return true;
+				});
+
+			customStatus.y = compareStatus2.y;
 			return true;
 		},
 		[&](CompareJumpStatus& customStatus) {
@@ -99,8 +121,7 @@ bool BitFsPyramidOscillation::execution()
 			AdvanceFrameWrite(Inputs(Buttons::A, 0, 0));
 			customStatus.y = marioState->pos[1];
 			return true;
-		}
-	);
+		});
 
 	auto adhocStatus2 = ExecuteAdhoc<CompareJumpStatus>([&](CompareJumpStatus& customStatus)
 		{

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_Iteration.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_Iteration.cpp
@@ -82,5 +82,5 @@ bool BitFsPyramidOscillation_Iteration::execution()
 
 bool BitFsPyramidOscillation_Iteration::assertion()
 {
-	return !BaseStatus.m64Diff.frames.empty();
+	return !IsDiffEmpty();
 }

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_Iteration.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_Iteration.cpp
@@ -42,8 +42,7 @@ bool BitFsPyramidOscillation_Iteration::execution()
 		Load(frame);
 		CustomStatus.speedBeforeTurning = marioState->forwardVel;
 		CustomStatus.initialXzSum		= _oscillationParams.initialXzSum;
-		auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill>(
-			_oscillationParams);
+		auto status = Execute<BitFsPyramidOscillation_TurnThenRunDownhill>(_oscillationParams);
 
 		// Keep iterating until we get a valid result, then keep iterating until
 		// we stop getting better results Once we get a valid result, we expect

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_RunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_RunDownhill.cpp
@@ -163,5 +163,5 @@ bool BitFsPyramidOscillation_RunDownhill::execution()
 
 bool BitFsPyramidOscillation_RunDownhill::assertion()
 {
-	return !BaseStatus.m64Diff.frames.empty();
+	return !IsDiffEmpty();
 }

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_RunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_RunDownhill.cpp
@@ -59,27 +59,22 @@ bool BitFsPyramidOscillation_RunDownhill::execution()
 		// Turnaround face angle is not guaranteed to be closer to one
 		// orientation or the other, so rely on caller to specify a close-enough
 		// target orientation
-		auto status = Test<GetMinimumDownhillWalkingAngle>(
-			_oscillationParams.roughTargetAngle, marioState->faceAngle[1]);
+		auto status = Test<GetMinimumDownhillWalkingAngle>(_oscillationParams.roughTargetAngle, marioState->faceAngle[1]);
 
 		// Terminate if unable to locate a downhill angle
 		if (!status.executed)
 			return true;
 
 		// Attempt to run downhill with minimum angle
-		int16_t intendedYaw = marioState->action == ACT_TURNING_AROUND ?
-			status.angleFacingAnalogBack :
-			  status.angleFacing;
-		auto stick			= Inputs::GetClosestInputByYawExact(
-					 intendedYaw, 32, camera->yaw, status.downhillRotation);
+		int16_t intendedYaw = marioState->action == ACT_TURNING_AROUND ? status.angleFacingAnalogBack : status.angleFacing;
+		auto stick = Inputs::GetClosestInputByYawExact(intendedYaw, 32, camera->yaw, status.downhillRotation);
 		AdvanceFrameWrite(Inputs(0, stick.first, stick.second));
 
 		// Terminate and roll back frame if Mario is no longer running on the
 		// platform
-		if ((marioState->action != ACT_WALKING &&
-			 marioState->action != ACT_FINISH_TURNING_AROUND) ||
-			marioState->marioObj->platform == NULL ||
-			marioState->marioObj->platform->behavior != pyramidBehavior)
+		if ((marioState->action != ACT_WALKING && marioState->action != ACT_FINISH_TURNING_AROUND)
+			|| marioState->marioObj->platform == NULL
+			|| marioState->marioObj->platform->behavior != pyramidBehavior)
 		{
 			Rollback(GetCurrentFrame() - 1);
 			return true;
@@ -134,23 +129,15 @@ bool BitFsPyramidOscillation_RunDownhill::execution()
 			normalDiff = fabs(pyramid->oTiltingPyramidNormalZ - prevNormalZ);
 		}
 
-		if (CustomStatus.framePassedEquilibriumPoint == -1 &&
-			tiltDirection == targetTiltDirection && normalDiff >= 0.0099999f)
+		if (CustomStatus.framePassedEquilibriumPoint == -1 && tiltDirection == targetTiltDirection && normalDiff >= 0.0099999f)
 		{
 			CustomStatus.passedEquilibriumSpeed		 = marioState->forwardVel;
 			CustomStatus.framePassedEquilibriumPoint = GetCurrentFrame() - 1;
-			CustomStatus.finalXzSum = pyramid->oTiltingPyramidNormalX *
-					(_oscillationParams.quadrant < 3 ? 1 : -1) +
-				pyramid->oTiltingPyramidNormalZ *
-					(_oscillationParams.quadrant == 1 ||
-							 _oscillationParams.quadrant == 4 ?
-						 1 :
-						   -1);
+			CustomStatus.finalXzSum =
+				pyramid->oTiltingPyramidNormalX * (_oscillationParams.quadrant < 3 ? 1 : -1) +
+				pyramid->oTiltingPyramidNormalZ * (_oscillationParams.quadrant == 1 || _oscillationParams.quadrant == 4 ? 1 : -1);
 
-			if (CustomStatus.finalXzSum <
-					_oscillationParams.targetXzSum - 0.00001 &&
-				CustomStatus.finalXzSum <
-					_oscillationParams.initialXzSum + 0.01f)
+			if (CustomStatus.finalXzSum < _oscillationParams.targetXzSum - 0.00001 && CustomStatus.finalXzSum < _oscillationParams.initialXzSum + 0.01f)
 			{
 				CustomStatus.tooUphill = true;
 				return true;

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnAroundAndRunDownhill.cpp
@@ -116,5 +116,5 @@ bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::execution()
 
 bool BitFsPyramidOscillation_TurnAroundAndRunDownhill::assertion()
 {
-	return !BaseStatus.m64Diff.frames.empty();
+	return !IsDiffEmpty();
 }

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill.cpp
@@ -103,7 +103,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill::execution()
 
 bool BitFsPyramidOscillation_TurnThenRunDownhill::assertion()
 {
-	if (BaseStatus.m64Diff.frames.empty())
+	if (IsDiffEmpty())
 		return false;
 
 	return true;

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
@@ -153,7 +153,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 
 bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::assertion()
 {
-	if (BaseStatus.m64Diff.frames.empty())
+	if (IsDiffEmpty())
 		return false;
 
 	if (CustomStatus.tooUphill || CustomStatus.tooDownhill)

--- a/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
+++ b/src/lib/tasfw-scripts-bitfs-pyramid-osc/src/BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle.cpp
@@ -50,20 +50,15 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 		// Don't want to turn around early, so cap intended yaw diff at 2048
 		int16_t intendedYaw = _angle;
 		if (abs(_angle - marioState->faceAngle[1]) > 2048)
-			intendedYaw = marioState->faceAngle[1] +
-				2048 * sign(_angle - marioState->faceAngle[1]);
+			intendedYaw = marioState->faceAngle[1] + 2048 * sign(_angle - marioState->faceAngle[1]);
 
 		auto inputs = Inputs::GetClosestInputByYawHau(_angle, 32, camera->yaw);
-		actualIntendedYaw = Inputs::GetIntendedYawMagFromInput(
-													inputs.first, inputs.second, camera->yaw)
-													.first;
+		actualIntendedYaw = Inputs::GetIntendedYawMagFromInput(inputs.first, inputs.second, camera->yaw).first;
 		AdvanceFrameWrite(Inputs(0, inputs.first, inputs.second));
 
-		if (
-			(marioState->action != ACT_WALKING &&
-			 marioState->action != ACT_FINISH_TURNING_AROUND) ||
-			marioState->floor->object == nullptr ||
-			marioState->floor->object->behavior != pyramidBehavior)
+		if ((marioState->action != ACT_WALKING && marioState->action != ACT_FINISH_TURNING_AROUND)
+			|| marioState->floor->object == nullptr
+			|| marioState->floor->object->behavior != pyramidBehavior)
 			return false;
 
 		// At least 16 speed is needed for turnaround
@@ -75,12 +70,10 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 
 		// Check if we need extra frames to wait for ACT_FINISH_TURNING_AROUND
 		// to expire
-		if (
-			marioState->faceAngle[1] == actualIntendedYaw &&
-			marioState->action == ACT_FINISH_TURNING_AROUND)
+		if (marioState->faceAngle[1] == actualIntendedYaw
+			&& marioState->action == ACT_FINISH_TURNING_AROUND)
 			CustomStatus.finishTurnaroundFailedToExpire = true;
-	} while (marioState->faceAngle[1] != actualIntendedYaw ||
-					 marioState->action == ACT_FINISH_TURNING_AROUND);
+	} while (marioState->faceAngle[1] != actualIntendedYaw || marioState->action == ACT_FINISH_TURNING_AROUND);
 
 	if (marioState->action != ACT_WALKING)
 	{
@@ -88,8 +81,7 @@ bool BitFsPyramidOscillation_TurnThenRunDownhill_AtAngle::execution()
 		return false;
 	}
 
-	ScriptStatus<BitFsPyramidOscillation_TurnAroundAndRunDownhill>
-		runDownhillStatus;
+	ScriptStatus<BitFsPyramidOscillation_TurnAroundAndRunDownhill> runDownhillStatus;
 	uint64_t initFrame = GetCurrentFrame();
 	//This should never reach 50 frames, but just in case
 	for (int i = 0; i < 100; i++)


### PR DESCRIPTION
Addresses https://github.com/TylerKehne/sm64-tas-scripting/issues/17.

Ad-hoc scripts run in the context of the script they are called in, but they have similar guarantees and performance to regular scripts. They can be used with custom statuses, but the custom status class must be defined beforehand (e.g. locally) and passed in via a template, and also included as an argument in the script itself.

The Compare methods compare adhoc scripts and select the best option according to a comparator function that is defined in a compare status class that must be passed in as a template.