### PR TITLE
fix to build with clang

### DIFF
--- a/src/lib/tasfw-core/include/tasfw/ScriptStatus.hpp
+++ b/src/lib/tasfw-core/include/tasfw/ScriptStatus.hpp
@@ -32,7 +32,7 @@ class ScriptStatus : public BaseScriptStatus, public TScript::CustomScriptStatus
 public:
 	ScriptStatus() : BaseScriptStatus(), TScript::CustomScriptStatus() {}
 
-	ScriptStatus(BaseScriptStatus baseStatus, TScript::CustomScriptStatus customStatus)
+	ScriptStatus(BaseScriptStatus baseStatus, typename TScript::CustomScriptStatus customStatus)
 		: BaseScriptStatus(baseStatus), TScript::CustomScriptStatus(customStatus) { }
 };
 


### PR DESCRIPTION
clang seems to have slightly different rules about when typename is needed, this doesn't seem to break anything, didn't check on msvc, so check there before you accept