### PR TITLE
adding missing include

### DIFF
--- a/src/lib/tasfw-core/include/tasfw/ScriptStatus.hpp
+++ b/src/lib/tasfw-core/include/tasfw/ScriptStatus.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "tasfw/Resource.hpp"
 #include <tasfw/Inputs.hpp>
 
 #ifndef SCRIPTSTATUS_H


### PR DESCRIPTION
I think this only compiles since ScriptStatus is after Resource alphabetically so we are relying on the include order to get the definition of Resource, we should just include it.