### PR TITLE
Use vcpkg and distribution packages instead of Conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,68 +24,10 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 		"Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-# Download conan-cmake
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-	message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-	file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.17.0/conan.cmake"
-		"${CMAKE_BINARY_DIR}/conan.cmake"
-		TLS_VERIFY ON)
-endif()
-
-include("${CMAKE_BINARY_DIR}/conan.cmake")
-
-# Install local packages
-# find_package(Python COMPONENTS Interpreter)
-# if (${Python_VERSION} VERSION_LESS "3.7.0")
-# message(FATAL_ERROR "Upgrade Python (min version 3.7.0)")
-# endif()
-# execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/conan_installer.py RESULT_VARIABLE RTC)
-# if (NOT ${RTC} EQUAL 0)
-# message(FATAL_ERROR "Local installer failed")
-# endif()
-
-# Dependency config
-conan_cmake_configure(
-	REQUIRES "nlohmann_json/3.10.5"
-	GENERATORS cmake_find_package
-)
-
-# Check if generator is multi-config
-get_property(is_multiconfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-
-# Setup packages using conan-cmake
-message("Generator is multi-config: ${is_multiconfig}")
-
-if(${is_multiconfig})
-	foreach(TYPE ${CMAKE_CONFIGURATION_TYPES})
-		message(STATUS "Installing Conan data for build type ${TYPE}")
-		conan_cmake_autodetect(SM64_TASFW_SETTINGS BUILD_TYPE ${TYPE})
-		conan_cmake_install(PATH_OR_REFERENCE .
-			BUILD missing
-			SETTINGS ${SM64_TASFW_SETTINGS}
-			SETTINGS "compiler.cppstd=20"
-			INSTALL_FOLDER "${CMAKE_BINARY_DIR}/CMakeFiles/conan_deps"
-		)
-	endforeach()
-else()
-	conan_cmake_autodetect(SM64_TASFW_SETTINGS)
-	conan_cmake_install(PATH_OR_REFERENCE .
-		BUILD missing
-		SETTINGS ${SM64_TASFW_SETTINGS}
-		SETTINGS "compiler.cppstd=20"
-		INSTALL_FOLDER "${CMAKE_BINARY_DIR}/CMakeFiles/conan_deps"
-	)
-endif()
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}/CMakeFiles/conan_deps")
-list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/CMakeFiles/conan_deps")
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # Import Conan packages
-foreach(PACKAGE IN ITEMS nlohmann_json)
-	find_package(${PACKAGE} REQUIRED)
-endforeach()
+find_package(nlohmann_json REQUIRED)
 
 # Library components
 add_subdirectory(src/lib)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,27 @@
 This project provides a framework for automating the SM64 TAS workflow. Very much a WIP at this time.
 
 # Building instructions
-This project is built using CMake. On the CLI:
-```bash
-cmake ..
+This project is built using CMake. 
+
+**Windows**
+- Install vcpkg
+- `vcpkg install nlohmann-json`
+
+```powershell
+mkdir build
+cd build
+cmake -DCMAKE_TOOLCHAIN_FILE="<path to vcpkg>\scripts\buildsystems\vcpkg.cmake" ..
 cmake --build .
 ```
 
+**MacOS and Linux**
+- Install `nlohmann-json` using your favourite package manager.
+```bash
+mkdir build
+cd build
+cmake ..
+cmake --build .
+```
 If you're using Visual Studio, open the root directory as a local folder. This enables VS's CMake integration. More detailed instructions can be found [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170#building-cmake-projects)
 
 # Configuration system


### PR DESCRIPTION
vcpkg appears to be a better package management solution on Windows. Unlike Conan, there isn't as much extra tooling that needs to be added per-package.

Unfortunately, vcpkg only allows building from source at the moment, so some packages may not download as quickly.

On the up side, official distribution packages can be used on Linux instead of Conan-provided ones.