### PR TITLE
Misc. desync fixes, performance improvements and refactoring

### DIFF
--- a/src/lib/tasfw-core/include/tasfw/Resource.t.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Resource.t.hpp
@@ -155,7 +155,10 @@ void Resource<TState>::FrameAdvance()
 template <class TState>
 bool Resource<TState>::shouldSave(int64_t estFrameAdvances) const
 {
-	if (nSaveStates == 0 || estFrameAdvances < 0)
+	if (estFrameAdvances == 0)
+		return false;
+
+	if (nSaveStates == 0 || nFrameAdvances == 0 || estFrameAdvances < 0)
 		return true;
 
 	double estTimeToSave = double(_totalSaveStateTime) / nSaveStates;
@@ -168,7 +171,10 @@ bool Resource<TState>::shouldSave(int64_t estFrameAdvances) const
 template <class TState>
 bool Resource<TState>::shouldLoad(int64_t framesAhead) const
 {
-	if (nLoadStates == 0 || framesAhead < 0)
+	if (framesAhead == 0)
+		return false;
+
+	if (nLoadStates == 0 || nFrameAdvances == 0 || framesAhead < 0)
 		return true;
 
 	double estTimeToLoad = double(_totalLoadStateTime) / nLoadStates;

--- a/src/lib/tasfw-core/include/tasfw/Script.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.hpp
@@ -76,18 +76,8 @@ public:
 
 	SaveMetadata() = default;
 
-	SaveMetadata(Script<TResource>* script) 
-	{
-		if (script)
-		{
-			this->script = script;
-			isStartSave = true;
-			frame = 0;
-			adhocLevel = -1;
-		}
-	}
-
-	SaveMetadata(Script<TResource>* script, int64_t frame, int64_t adhocLevel) : script(script), frame(frame), adhocLevel(adhocLevel) { }
+	SaveMetadata(Script<TResource>* script, int64_t frame, int64_t adhocLevel, bool isStartSave = false)
+		: script(script), frame(frame), adhocLevel(adhocLevel), isStartSave(isStartSave) { }
 
 	SlotHandle<TResource>* GetSlotHandle();
 	bool IsValid();

--- a/src/lib/tasfw-core/include/tasfw/Script.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.hpp
@@ -117,8 +117,7 @@ protected:
 		TScript script = TScript(std::forward<Us>(params)...);
 		script.Initialize(this);
 
-		if (script.checkPreconditions() && script.execute())
-			script.checkPostconditions();
+		script.Run();
 
 		// Load if necessary
 		Revert(initialFrame, script.BaseStatus[0].m64Diff, script.saveBank[0]);
@@ -140,8 +139,7 @@ protected:
 		TScript script = TScript(std::forward<Us>(params)...);
 		script.Initialize(this);
 
-		if (script.checkPreconditions() && script.execute())
-			script.checkPostconditions();
+		script.Run();
 
 		ApplyChildDiff(script.BaseStatus[0], script.saveBank[0], initialFrame);
 
@@ -240,9 +238,7 @@ private:
 	std::unordered_map<int64_t, std::set<int64_t>> loadTracker;// track past loads to know whether a cached save is optimal
 	Script* _parentScript;
 
-	bool checkPreconditions();
-	bool execute();
-	bool checkPostconditions();
+	bool Run();
 
 	void Initialize(Script<TResource>* parentScript);
 	SaveMetadata<TResource> GetLatestSave(int64_t frame);
@@ -306,8 +302,7 @@ public:
 		script.resource = &resource;
 		script.Initialize(nullptr);
 
-		if (script.checkPreconditions() && script.execute())
-			script.checkPostconditions();
+		script.Run();
 
 		//Dispose of slot handles before resource goes out of scope because they trigger destructor events in the resource.
 		script.saveBank[0].erase(script.saveBank[0].begin(), script.saveBank[0].end());
@@ -328,8 +323,7 @@ public:
 		script.resource = &resource;
 		script.Initialize(nullptr);
 
-		if (script.checkPreconditions() && script.execute())
-			script.checkPostconditions();
+		script.Run();
 
 		//Dispose of slot handles before resource goes out of scope because they trigger destructor events in the resource.
 		script.saveBank[0].erase(script.saveBank[0].begin(), script.saveBank[0].end());
@@ -353,8 +347,7 @@ public:
 		script.resource = &resource;
 		script.Initialize(nullptr);
 
-		if (script.checkPreconditions() && script.execute())
-			script.checkPostconditions();
+		script.Run();
 
 		//Dispose of slot handles before resource goes out of scope because they trigger destructor events in the resource.
 		script.saveBank[0].erase(script.saveBank[0].begin(), script.saveBank[0].end());
@@ -378,8 +371,7 @@ public:
 		script.resource = &resource;
 		script.Initialize(nullptr);
 
-		if (script.checkPreconditions() && script.execute())
-			script.checkPostconditions();
+		script.Run();
 
 		//Dispose of slot handles before resource goes out of scope because they trigger destructor events in the resource.
 		script.saveBank[0].erase(script.saveBank[0].begin(), script.saveBank[0].end());

--- a/src/lib/tasfw-core/include/tasfw/Script.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.hpp
@@ -153,11 +153,7 @@ protected:
 		if (script.checkPreconditions() && script.execute())
 			script.checkPostconditions();
 
-		// Revert state if assertion fails, otherwise apply diff
-		if (!script.BaseStatus[0].asserted || script.BaseStatus[0].m64Diff.frames.empty())
-			Revert(initialFrame, script.BaseStatus[0].m64Diff);
-		else
-			ApplyChildDiff(script.BaseStatus[0], initialFrame);
+		ApplyChildDiff(script.BaseStatus[0], script.saveBank[0], initialFrame);
 
 		BaseStatus[_adhocLevel].nLoads += script.BaseStatus[0].nLoads;
 		BaseStatus[_adhocLevel].nSaves += script.BaseStatus[0].nSaves;
@@ -269,7 +265,7 @@ private:
 	void AdvanceFrameRead(uint64_t& counter);
 	uint64_t GetFrameCounter(InputsMetadata<TResource> cachedInputs);
 	uint64_t IncrementFrameCounter(InputsMetadata<TResource> cachedInputs);
-	void ApplyChildDiff(const BaseScriptStatus& status, int64_t initialFrame);
+	void ApplyChildDiff(const BaseScriptStatus& status, std::map<int64_t, SlotHandle<TResource>>& childSaveBank, int64_t initialFrame);
 	SaveMetadata<TResource> Save(int64_t adhocLevel);
 	void LoadBase(uint64_t frame, bool desync);
 

--- a/src/lib/tasfw-core/include/tasfw/Script.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.hpp
@@ -273,6 +273,7 @@ private:
 	uint64_t IncrementFrameCounter(InputsMetadata<TResource> cachedInputs);
 	void ApplyChildDiff(const BaseScriptStatus& status, int64_t initialFrame);
 	SaveMetadata<TResource> Save(int64_t adhocLevel);
+	void LoadBase(uint64_t frame, bool desync);
 
 	template <typename F>
 	BaseScriptStatus ExecuteAdhocBase(F adhocScript);

--- a/src/lib/tasfw-core/include/tasfw/Script.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.hpp
@@ -131,7 +131,7 @@ protected:
 			script.checkPostconditions();
 
 		// Load if necessary
-		Revert(initialFrame, script.BaseStatus[0].m64Diff);
+		Revert(initialFrame, script.BaseStatus[0].m64Diff, script.saveBank[0]);
 
 		BaseStatus[_adhocLevel].nLoads += script.BaseStatus[0].nLoads;
 		BaseStatus[_adhocLevel].nSaves += script.BaseStatus[0].nSaves;
@@ -261,7 +261,7 @@ private:
 	InputsMetadata<TResource> GetInputsMetadataAndCache(int64_t frame);
 	void DeleteSave(int64_t frame, int64_t adhocLevel);
 	void SetInputs(Inputs inputs);
-	void Revert(uint64_t frame, const M64Diff& m64);
+	void Revert(uint64_t frame, const M64Diff& m64, std::map<int64_t, SlotHandle<TResource>>& childSaveBank);
 	void AdvanceFrameRead(uint64_t& counter);
 	uint64_t GetFrameCounter(InputsMetadata<TResource> cachedInputs);
 	uint64_t IncrementFrameCounter(InputsMetadata<TResource> cachedInputs);

--- a/src/lib/tasfw-core/include/tasfw/Script.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.hpp
@@ -123,7 +123,6 @@ protected:
 	{
 		// Save state if performant
 		uint64_t initialFrame = GetCurrentFrame();
-		OptionalSave();
 
 		TScript script = TScript(std::forward<Us>(params)...);
 		script.Initialize(this);
@@ -147,7 +146,6 @@ protected:
 	{
 		// Save state if performant
 		uint64_t initialFrame = GetCurrentFrame();
-		OptionalSave();
 
 		TScript script = TScript(std::forward<Us>(params)...);
 		script.Initialize(this);

--- a/src/lib/tasfw-core/include/tasfw/Script.t.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.t.hpp
@@ -42,35 +42,35 @@ void Script<TResource>::Initialize(Script<TResource>* parentScript)
 }
 
 template <derived_from_specialization_of<Resource> TResource>
-bool Script<TResource>::checkPreconditions()
+bool Script<TResource>::Run()
 {
+	// Validate
 	auto start = std::chrono::high_resolution_clock::now();
 	BaseStatus[_adhocLevel].validated = ExecuteAdhoc([&] { return validation(); }).executed;
 	auto finish = std::chrono::high_resolution_clock::now();
 
 	BaseStatus[_adhocLevel].validationDuration = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
-	return BaseStatus[_adhocLevel].validated;
-}
 
-template <derived_from_specialization_of<Resource> TResource>
-bool Script<TResource>::execute()
-{
-	auto start = std::chrono::high_resolution_clock::now();
+	if (!BaseStatus[_adhocLevel].validated)
+		return false;
+
+	// Execute
+	start = std::chrono::high_resolution_clock::now();
 	BaseStatus[_adhocLevel].executed = ModifyAdhoc([&] { return execution(); }).executed;
-	auto finish = std::chrono::high_resolution_clock::now();
+	finish = std::chrono::high_resolution_clock::now();
 
 	BaseStatus[_adhocLevel].executionDuration = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
-	return BaseStatus[_adhocLevel].executed;
-}
 
-template <derived_from_specialization_of<Resource> TResource>
-bool Script<TResource>::checkPostconditions()
-{
-	auto start = std::chrono::high_resolution_clock::now();
+	if (!BaseStatus[_adhocLevel].executed)
+		return false;
+
+	// Assert
+	start = std::chrono::high_resolution_clock::now();
 	BaseStatus[_adhocLevel].asserted = ExecuteAdhoc([&] { return assertion(); }).executed;
-	auto finish = std::chrono::high_resolution_clock::now();
+	finish = std::chrono::high_resolution_clock::now();
 
 	BaseStatus[_adhocLevel].assertionDuration = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
+
 	return BaseStatus[_adhocLevel].asserted;
 }
 
@@ -907,7 +907,15 @@ BaseScriptStatus Script<TResource>::ExecuteAdhocBase(F adhocScript)
 	BaseStatus[_adhocLevel].validated = true;
 
 	auto start = std::chrono::high_resolution_clock::now();
-	BaseStatus[_adhocLevel].executed = adhocScript();
+	try
+	{
+		BaseStatus[_adhocLevel].executed = adhocScript();
+	}
+	catch (std::exception e)
+	{
+		// End application if exception occurs
+		throw std::runtime_error(e.what());
+	}
 	auto finish = std::chrono::high_resolution_clock::now();
 
 	BaseStatus[_adhocLevel].executionDuration =

--- a/src/lib/tasfw-core/include/tasfw/Script.t.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.t.hpp
@@ -429,7 +429,7 @@ SaveMetadata<TResource> Script<TResource>::GetLatestSave(int64_t frame)
 		return bestSave;
 
 	//Default to initial save
-	return SaveMetadata<TResource>(this);
+	return SaveMetadata<TResource>(this, _initialFrame, 0, true);
 }
 
 template <derived_from_specialization_of<Resource> TResource>

--- a/src/lib/tasfw-core/include/tasfw/Script.t.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.t.hpp
@@ -358,8 +358,9 @@ SaveMetadata<TResource> Script<TResource>::GetLatestSave(int64_t frame)
 		}
 
 		// Don't search past start of m64 diff to avoid desync
-		earlyFrame = !BaseStatus[adhocLevel].m64Diff.frames.empty() ?
-			(std::min)(BaseStatus[adhocLevel].m64Diff.frames.begin()->first, (uint64_t)earlyFrame) : frame;
+		earlyFrame = !BaseStatus[adhocLevel].m64Diff.frames.empty()
+			? (std::min)(BaseStatus[adhocLevel].m64Diff.frames.begin()->first, (uint64_t)earlyFrame)
+			: (std::min)(frame, earlyFrame);
 
 		//If save is not before the start of the diff, we have the best possible save, so return it
 		if (bestSave.frame >= 0 && bestSave.frame >= earlyFrame)

--- a/src/lib/tasfw-core/include/tasfw/ScriptStatus.hpp
+++ b/src/lib/tasfw-core/include/tasfw/ScriptStatus.hpp
@@ -14,9 +14,6 @@ public:
 	bool validated = false;
 	bool executed = false;
 	bool asserted = false;
-	bool validationThrew = false;
-	bool executionThrew = false;
-	bool assertionThrew = false;
 	uint64_t validationDuration = 0;
 	uint64_t executionDuration = 0;
 	uint64_t assertionDuration = 0;
@@ -54,7 +51,6 @@ public:
 	AdhocBaseScriptStatus(BaseScriptStatus baseStatus)
 	{
 		executed = baseStatus.executed;
-		executionThrew = baseStatus.executionThrew;
 		executionDuration = baseStatus.executionDuration;
 		nLoads = baseStatus.nLoads;
 		nSaves = baseStatus.nSaves;


### PR DESCRIPTION
This was meant to be a small fix for a desync I found in the Restore() method, but while fixing it I started noticing other issues and design inconsistencies related to the method, and fixing those uncovered more issues, etc.. The end result is that a bunch of stuff has been fixed, but also:

-Regular scripts now run as ad-hoc scripts under the hood
-Validation and assertion now run as separate ad-hoc scripts that ensure they will not alter state
-Exceptions are no longer handled and the application will terminate if an unhandled exception occurs in a script
-When a script (ad-hoc or otherwise) finishes, any saves it has will be transferred to the parent as long as they are synced

Also reverting back to Conan for dependencies for now as vcpkg was not working on Windows.