### PR TITLE
Add method for faraway loads

### DIFF
--- a/src/bin/bitfs-turnaround/src/main.cpp
+++ b/src/bin/bitfs-turnaround/src/main.cpp
@@ -30,8 +30,7 @@ public:
 
 	bool execution()
 	{
-		Load(3536);
-		Save();
+		LongLoad(3536);
 		auto status = Modify<BitFsPyramidOscillation>(0.74f, 4);
 		return true;
 	}

--- a/src/lib/tasfw-core/include/tasfw/Script.hpp
+++ b/src/lib/tasfw-core/include/tasfw/Script.hpp
@@ -555,6 +555,7 @@ protected:
 	void OptionalSave();
 	void Save();
 	void Load(uint64_t frame);
+	void LongLoad(int64_t frame);
 	void Rollback(uint64_t frame);
 	void RollForward(int64_t frame);
 	void Restore(int64_t frame);


### PR DESCRIPTION
The LongLoad() method ignores the normal metrics for performance optimization because the assumption is that the frames in between the most recent save before the target frame and the target frame itself are unlikely to be accessed again.

Also changed the frame counter increment to prefix, as the main reason for the postfix was to prevent unnecessary saves in the situations addressed by this new method.

Also made Save() create a save on the state owner with a cached version in the current script, which is more optimal.

Addresses https://github.com/TylerKehne/sm64-tas-scripting/issues/48.